### PR TITLE
Do not crash on empty body on notifications

### DIFF
--- a/async_upnp_client/async_upnp_client.py
+++ b/async_upnp_client/async_upnp_client.py
@@ -244,7 +244,7 @@ class UpnpService(object):
 
         el_root = ET.fromstring(body)
         el_last_change = el_root.find('.//LastChange')
-        if el_last_change is None:
+        if el_last_change is None or el_last_change.text is None:
             _LOGGER.debug("Got NOTIFY without body, ignoring")
             return
 


### PR DESCRIPTION
While testing https://github.com/home-assistant/home-assistant/pull/14749 I noticed that it crashes when receiving a notification from a xiaomi wifi speaker (https://www.gearbest.com/speakers/pp_590443.html) -- I'm not sure if empty values are accepted, but I think it's better to avoid crashing here anyway.

```
Jun 21 03:12:20 nuc hass[10355]:   File "/home/hass/home-assistant/homeassistant/components/media_player/dlna_dmr.py", line 408, in async_update
Jun 21 03:12:20 nuc hass[10355]:     await self._async_init_device()
Jun 21 03:12:20 nuc hass[10355]:   File "/home/hass/home-assistant/homeassistant/components/media_player/dlna_dmr.py", line 402, in _async_init_device
Jun 21 03:12:20 nuc hass[10355]:     self._notify_view.register_service(sid, service)
Jun 21 03:12:20 nuc hass[10355]:   File "/home/hass/home-assistant/homeassistant/components/media_player/dlna_dmr.py", line 301, in register_service
Jun 21 03:12:20 nuc hass[10355]:     service.on_notify(item['headers'], item['body'])
Jun 21 03:12:20 nuc hass[10355]:   File "/home/hass/venv/lib/python3.6/site-packages/async_upnp_client/async_upnp_client.py", line 252, in on_notify
Jun 21 03:12:20 nuc hass[10355]:     el_event = ET.fromstring(el_last_change.text)
Jun 21 03:12:20 nuc hass[10355]:   File "/usr/lib/python3.6/xml/etree/ElementTree.py", line 1314, in XML
Jun 21 03:12:20 nuc hass[10355]:     parser.feed(text)
Jun 21 03:12:20 nuc hass[10355]: TypeError: a bytes-like object is required, not 'NoneType'
```

Example element (formated for readability):
```
{'headers': <CIMultiDictProxy('Host': '192.168.250.120:9999',
'Content-Type': 'text/xml; charset="utf-8"',
'Nt': 'upnp:event',
'Nts': 'upnp:propchange',
'SID': 'uuid:2XXXXXXXXXXX',
'Transfer-Encoding': 'chunked', 
'Seq': '0', 'Connection': 'close')>, 
'body':
'<?xml version="1.0"?>
<e:propertyset xmlns:e="urn:schemas-upnp-org:event-1-0">
<e:property>
<LastChange></LastChange>
</e:property>
</e:propertyset>'}
```