### PR TITLE
Do not crash when state variable is not available, allow easier event debugging

### DIFF
--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -28,6 +28,7 @@ def dlna_handle_notify_last_change(state_var):
     changed_state_variables = []
 
     el_event = ET.fromstring(state_var.value)
+    _LOGGER.debug("Event payload: %s" % state_var.value)
     for el_instance in el_event:
         if not el_instance.tag.endswith("}InstanceID"):
             continue
@@ -39,6 +40,9 @@ def dlna_handle_notify_last_change(state_var):
         for el_state_var in el_instance:
             name = el_state_var.tag.split('}')[1]
             state_var = service.state_variable(name)
+            if state_var is None:
+                _LOGGER.debug("State variable %s does not exist, ignoring", name)
+                continue
 
             value = el_state_var.attrib['val']
             try:


### PR DESCRIPTION
While testing the troublesome xiaomi player, it keeps crashing on the variables defined under a `mi` namespace, this PR just avoids that crash by ignoring the missing variables & adds a debug statement for further event debugging.

```
Jul 02 22:10:42 nuc hass[28316]: 2018-07-02 22:10:42 INFO (MainThread) [async_upnp_client.utils] el_event: <Event xmlns="urn:schemas-upnp-org:metadata-1-0/AVT/" xmlns:mi="urn:schemas-mi-com:metadata-1-0/">
Jul 02 22:10:42 nuc hass[28316]:     <InstanceID val="0">
Jul 02 22:10:42 nuc hass[28316]:         <TransportState val="STOPPED"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentPlayMode val="NORMAL"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentTransportActions val="Play"/>
Jul 02 22:10:42 nuc hass[28316]:         <NumberOfTracks val="1"/>
Jul 02 22:10:42 nuc hass[28316]:         <RelativeTimePosition val="00:00:00"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentTrack val="1"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentTrackURI val="http://192.168.XX.XX:8123/api/tts_proxy/3da541559918a808c2402bba5012f6c60b27661c_en-us_-_picotts.wav"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentTrackDuration val="00:00:00"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentMediaDuration val="00:00:00"/>
Jul 02 22:10:42 nuc hass[28316]:         <AVTransportURI val="http://192.168.XX.XX:8123/api/tts_proxy/3da541559918a808c2402bba5012f6c60b27661c_en-us_-_picotts.wav"/>
Jul 02 22:10:42 nuc hass[28316]:         <CurrentTrackMetaData val="&lt;DIDL-Lite xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot; xmlns:upnp=&quot;urn:schemas-upnp-org:metadata-1-0/upnp/&quot; xmlns=&quot;urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/&quot;&gt;&lt;item id=&quot;0&quot; parentID=&quot;0&quot; restricted=&quot;1&quot;&gt;&lt;dc:title&gt;Home Assistant&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.audioItem&lt;/upnp:class&gt;&lt;res protocolInfo=&quot;http-get:*:audio/x-wav:DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=00000000000000000000000000000000&quot;&gt;http://192.168.XX.XX:8123/api/tts_proxy/3da541559918a808c2402bba5012f6c60b27661c_en-us_-_picotts.wav&lt;/res&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;"/>
Jul 02 22:10:42 nuc hass[28316]:         <mi:NextTrackURI val=""/>
Jul 02 22:10:42 nuc hass[28316]:         <mi:NextTrackMetaData val=""/>
Jul 02 22:10:42 nuc hass[28316]:         <mi:Transport val="AVT"/>
Jul 02 22:10:42 nuc hass[28316]:         <mi:SystemUpdateId value="157"/>
Jul 02 22:10:42 nuc hass[28316]:     </InstanceID>
Jul 02 22:10:42 nuc hass[28316]: </Event>
Jul 02 22:10:42 nuc hass[28316]: 2018-07-02 22:10:42 WARNING (MainThread) [async_upnp_client.utils] State variable NextTrackURI does not exist
Jul 02 22:10:42 nuc hass[28316]: 2018-07-02 22:10:42 WARNING (MainThread) [async_upnp_client.utils] State variable NextTrackMetaData does not exist
Jul 02 22:10:42 nuc hass[28316]: 2018-07-02 22:10:42 WARNING (MainThread) [async_upnp_client.utils] State variable Transport does not exist
Jul 02 22:10:42 nuc hass[28316]: 2018-07-02 22:10:42 WARNING (MainThread) [async_upnp_client.utils] State variable SystemUpdateId does not exist
```