### PR TITLE
Install the command line tool via setuptools' console_scripts entrypoint

### DIFF
--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -185,7 +185,7 @@ async def async_main():
         parser.print_usage()
 
 
-if __name__ == '__main__':
+def main():
     loop = asyncio.get_event_loop()
 
     try:
@@ -194,3 +194,7 @@ if __name__ == '__main__':
         loop.run_until_complete(event_handler.async_unsubscribe_all())
     finally:
         loop.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """CLI UPnP client module."""
+# pylint: disable=invalid-name
 
 import argparse
 import asyncio
@@ -137,7 +138,7 @@ async def call_action(device: UpnpDevice, call_action_args):
 
 async def subscribe(device: UpnpDevice, subscribe_args):
     """Subscribe to service(s) and output updates."""
-    global event_handler
+    global event_handler  # pylint: disable=global-statement
 
     # start notify server/event handler
     host, port = bind_host_port()

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     tests_require=TEST_REQUIRES,
     cmdclass={'test': PyTest},
-    scripts=[
-        'bin/upnp-client',
-    ]
+    entry_points={
+        'console_scripts': ['upnp-client=async_upnp_client.cli:main']
+    },
 )


### PR DESCRIPTION
The previous option of installing it via scripts= didn't add a shebang to the
file, meaning that if you actually tried to call it directly, it was interpreted
as a shell script. Using the console_scripts entrypoint to install it
automatically installs a wrapper scripts that calls the main function that has
the correct shebang (for example in a virtualenv).