### PR TITLE
Ignore whitespace around state variable names in XML

### DIFF
--- a/async_upnp_client/__init__.py
+++ b/async_upnp_client/__init__.py
@@ -914,7 +914,8 @@ class UpnpFactory:
         """Parse XML for state variable."""
         # pylint: disable=no-self-use
         info = {
-            'name': state_variable_xml.find('service:name', NS).text,
+            # Some buggy implementations have whitespace around var names
+            'name': state_variable_xml.find('service:name', NS).text.strip(),
             'type_info': {}
         }
         type_info = info['type_info']


### PR DESCRIPTION
I'm experimenting with a Samsung printer which has preceding whitespace in its state variables listing for one variable name, like ` <name> JobIdList</name>`, but not when it refers to that variable elsewhere. I suppose it would be ok to just ignore all surrounding whitespace for var names -- at least this fixes it for this particular case.