### PR TITLE
Fix service resubscription failure: wrong timeout format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 0.14.8 (unreleased)
 
 - Added the disable_unknown_out_argument_error to disable exception raising for not found arguments (@p3g4asus)
+- Fix service resubscription failure: wrong timeout format (@romaincolombo)
 
 
 0.14.7 (2019-03-29)

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -175,7 +175,7 @@ class UpnpEventHandler:
         headers = {
             'HOST': urllib.parse.urlparse(service.event_sub_url).netloc,
             'SID': sid,
-            'TIMEOUT': 'Second-' + str(timeout),
+            'TIMEOUT': 'Second-' + str(timeout.seconds),
         }
         response_status, response_headers, _ = \
             await self._requester.async_http_request('SUBSCRIBE', service.event_sub_url, headers)


### PR DESCRIPTION
Resubscription to Upnp service fails due to timeout value.
See Issue #38 