### PR TITLE
Client_factory: Return empty root node when response_body is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.14.15 (unreleased)
 
+- Do not crash on empty XML file (@ekandler)
 
 
 0.14.14 (2020-04-25)

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -292,6 +292,8 @@ class UpnpFactory:
 
         if status_code != 200:
             raise UpnpError("Received status code: {}".format(status_code))
-
+            
+        if not response_body:
+            return ET.Element('root')
         root = DET.fromstring(response_body)  # type: ET.Element
         return root

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -292,8 +292,9 @@ class UpnpFactory:
 
         if status_code != 200:
             raise UpnpError("Received status code: {}".format(status_code))
-            
+
         if not response_body:
             return ET.Element('root')
+
         root = DET.fromstring(response_body)  # type: ET.Element
         return root


### PR DESCRIPTION
This change prevents a crash when the response body of a parsed service-xml file is empty.

I noticed the issue with my Hama Sirium 4000ABT soundbar, which returns this service list in its description.xml:
```
   <service>
    <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
    <serviceId>urn:upnp-org:serviceId:RenderingControl</serviceId>
    <SCPDURL>/RenderingControl.xml</SCPDURL>
    <controlURL>/RenderingControl</controlURL>
    <eventSubURL>/RenderingControl/eventSub</eventSubURL>
   </service>
   <service>
    <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
    <serviceId>urn:upnp-org:serviceId:AVTransport</serviceId>
    <SCPDURL>/AVTransport.xml</SCPDURL>
    <controlURL>/AVTransport</controlURL>
    <eventSubURL>/AVTransport/eventSub</eventSubURL>
   </service>
   <service>
    <serviceType>urn:schemas-upnp-org:service:ConnectionManager:1</serviceType>
    <serviceId>urn:upnp-org:serviceId:ConnectionManager</serviceId>
    <SCPDURL>/ConnectionManager.xml</SCPDURL>
    <controlURL>/ConnectionManager</controlURL>
    <eventSubURL>/ConnectionManager/eventSub</eventSubURL>
   </service>
   <service>
    <serviceType>urn:schemas-tencent-com:service:QPlay:1</serviceType>
    <serviceId>urn:tencent-com:serviceId:QPlay</serviceId>
    <SCPDURL>/QPlay.xml</SCPDURL>
    <controlURL>/QPlay</controlURL>
    <eventSubURL>/QPlay/eventSub</eventSubURL>
   </service>
  </serviceList>
```

The last service, the QPlay.xml, is an empty xml file.
As the client factory tries to parse this empty xml file, a crash occures in `root = DET.fromstring(response_body)`.