### PR TITLE
Print ISO8601 timestamp instead of epoch seconds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 0.14.15 (unreleased)
 
 - Do not crash on empty XML file (@ekandler)
+- Option to print timestamp in ISO8601 (@kitlaan)
 
 
 0.14.14 (2020-04-25)


### PR DESCRIPTION
Hi!  A minor usability enhancement for the CLI.

I wasn't sure whether to utilize an option to output an ISO8601 timestamp, versus just including both epoch + ISO8601.
And then I wasn't sure whether to follow how `date` allows formatting ISO8601, so went the simple route.

Take the code as you will; I'm not even sure I ultimately needed this for my own usage.