### PR TITLE
Remove pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES=[
     'voluptuous>=0.11.1',
     'aiohttp>=3.3.2',
     'async-timeout>=3.0.0',
-    'python-didl-lite>=1.2.4,<1.3',
+    'python-didl-lite~=1.2.4',
     'defusedxml>=0.5.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES=[
     'voluptuous>=0.11.1',
     'aiohttp>=3.3.2',
     'async-timeout>=3.0.0',
-    'python-didl-lite==1.2.4',
+    'python-didl-lite>=1.2.4,<1.3',
     'defusedxml>=0.5.0',
 ]
 


### PR DESCRIPTION
The pinning of `python-didl-lite` to 1.2.4 block the installation of the package on Fedora. Fedora ships `python-didl-lite-1.2.5`.

