### PR TITLE
utils.py: Fix time_to_str() minutes calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.15.1 (unreleased)
 
+- Fix timespan formatting for content > 1h
 
 0.15.0 (2021-03-13)
 

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -73,7 +73,7 @@ def time_to_str(time: timedelta) -> str:
     target = {
         "sign": "-" if time.total_seconds() < 0 else "",
         "hours": int(total_seconds // 3600),
-        "minutes": int(total_seconds // 60),
+        "minutes": int(total_seconds % 3600 // 60),
         "seconds": int(total_seconds % 60),
     }
     return "{sign}{hours}:{minutes}:{seconds}".format(**target)


### PR DESCRIPTION
```
>>> s = (60 * 60 * 1) + (60 * 2) + 3
>>> print("%02i:%02i:%02i" % (s // 3600, s // 60, s % 60))
01:62:03
>>> print("%02i:%02i:%02i" % (s // 3600, s % 3600 // 60, s % 60))
01:02:03
```

I don't really need my name in the changelog but will add a short note if you insist.