### PR TITLE
aiohttp.py: Handle aiohttp decode errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.15.1 (unreleased)
 
+- Try to fix invalid device encodings
 
 0.15.0 (2021-03-13)
 

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -65,7 +65,11 @@ class AiohttpRequester(UpnpRequester):
 
                     resp_body: Union[str, bytes, None] = None
                     if body_type == "text":
-                        resp_body = await response.text()
+                        try:
+                            resp_body = await response.text()
+                        except UnicodeDecodeError as exception:
+                            resp_body = await response.read()
+                            resp_body = resp_body.decode(exception.encoding, errors='replace')
                     elif body_type == "raw":
                         resp_body = await response.read()
                     elif body_type == "ignore":


### PR DESCRIPTION
Triggered with some ancient filenames encoded with extended ASCII, served by minidlna.
There are two other solutions:

1) Undocumented 'errors' argument for aiohttp: response.text(errors='replace'):
https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.BaseRequest.text
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client_reqrep.py#L1007

2) Always use response.read() and decode manually based on response.charset (which may actually be None)

I don't really need my name in the changelog but will add a short note if you insist.