### PR TITLE
Add function to find service by `service_id`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 0.16.1 (unreleased)
 
 - Don't double-unescape action responses (#50)
+- Add `UpnpDevice.service_id()` to get service by service_id. (@bazwilliams)
 
 
 0.16.0 (2021-03-30)

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -217,6 +217,13 @@ class UpnpDevice:
         """Get service by service_type."""
         return self.services[service_type]
 
+    def service_id(self, service_id: str) -> Optional["UpnpService"]:
+        """Get service by service_id."""
+        for service in self.services.values():
+            if service.service_id == service_id:
+                return service
+        return None
+
     async def async_ping(self) -> None:
         """Ping the device."""
         await self.requester.async_http_request("GET", self.device_url)

--- a/tests/test_upnp_client.py
+++ b/tests/test_upnp_client.py
@@ -32,6 +32,9 @@ class TestUpnpStateVariable:
         service = device.service("urn:schemas-upnp-org:service:RenderingControl:1")
         assert service
 
+        service_by_id = device.service_id("urn:upnp-org:serviceId:RenderingControl")
+        assert service_by_id == service
+
         state_var = service.state_variable("Volume")
         assert state_var
 


### PR DESCRIPTION
This introduces a library level function to find a service using a `service_id` in addition to `service_type`. This can be useful if the version of the service is likely to be incremented. 

fixes #61 