### PR TITLE
Strip spaces, line endings and null characters before parsing XML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.16.3 (unreleased)
 
+- Strip spaces, line endings and null characters before parsing XML (@apal0934)
 
 0.16.2 (2021-04-25)
 

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -619,7 +619,7 @@ class UpnpAction:
     ) -> Mapping[str, Any]:
         """Parse response from called Action."""
         # pylint: disable=unused-argument
-        xml = DET.fromstring(response_body)
+        xml = DET.fromstring(response_body.rstrip(" \t\r\n\0"))
 
         query = ".//soap_envelope:Body/soap_envelope:Fault"
         if xml.find(query, NS):


### PR DESCRIPTION
Some routers (DSL-3900) send null terminating characters (\0) at the end of their XML which breaks parsing. This change strips the invalid characters from the end of the response before parsing (fixes #63 )

I only have the 1 router to test with, but I can't imagine stripping newlines would break functionality with any others.