### PR TITLE
Deferred event url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.18.1 (unreleased)
 
+- Defer event callback URL determination until event subscriptions are created (@chishm)
 
 0.18.0 (2021-05-23)
 

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-import socket
 from asyncio.events import AbstractEventLoop, AbstractServer
 from typing import Any, Mapping, Optional, Tuple, Union
 
@@ -14,23 +13,6 @@ import async_timeout
 from async_upnp_client import UpnpEventHandler, UpnpRequester
 
 _LOGGER = logging.getLogger(__name__)
-
-
-EXTERNAL_IP = "1.1.1.1"
-
-
-def get_local_ip(target_host: Optional[str] = None) -> str:
-    """Try to get the local IP of this machine, used to talk to target_url."""
-    target_host = target_host or EXTERNAL_IP
-    target_port = 80
-
-    try:
-        temp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        temp_sock.connect((target_host, target_port))
-        local_ip: str = temp_sock.getsockname()[0]
-        return local_ip
-    finally:
-        temp_sock.close()
 
 
 class AiohttpRequester(UpnpRequester):

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -166,7 +166,7 @@ class AiohttpNotifyServer:
         # All ports that the event server is listening on (maybe multiple IP stacks)
         if self._server.sockets:
             listen_ports = {
-                AddressFamily(sock.family): sock.getsockname()[0]
+                AddressFamily(sock.family): sock.getsockname()[1]
                 for sock in self._server.sockets
             }
         else:
@@ -174,6 +174,7 @@ class AiohttpNotifyServer:
             listen_ports = {}
 
         # Set event_handler's listen_ports  for it to format the callback_url correctly
+        _LOGGER.debug("event_handler listening on %s", listen_ports)
         self.event_handler.listen_ports = listen_ports
 
     async def stop_server(self) -> None:

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 from asyncio.events import AbstractEventLoop, AbstractServer
+from socket import AddressFamily  # pylint: disable=no-name-in-module
 from typing import Any, Mapping, Optional, Tuple, Union
 
 import aiohttp
@@ -118,10 +119,12 @@ class AiohttpSessionRequester(UpnpRequester):
 class AiohttpNotifyServer:
     """AIO HTTP Server to handle incoming events."""
 
+    CALLBACK_URL_FMT = "http://{host}:{port}/notify"
+
     def __init__(
         self,
         requester: UpnpRequester,
-        listen_port: int,
+        listen_port: int = 0,
         listen_host: Optional[str] = None,
         callback_url: Optional[str] = None,
         loop: Optional[AbstractEventLoop] = None,
@@ -129,16 +132,20 @@ class AiohttpNotifyServer:
         """Initialize."""
         # pylint: disable=too-many-arguments
         self._listen_port = listen_port
-        self._listen_host = listen_host or get_local_ip()
-        self._callback_url = callback_url or "http://{}:{}/notify".format(
-            self._listen_host, self._listen_port
-        )
+        self._listen_host = listen_host
         self._loop = loop or asyncio.get_event_loop()
 
         self._aiohttp_server: Optional[aiohttp.web.Server] = None
         self._server: Optional[AbstractServer] = None
 
-        self.event_handler = UpnpEventHandler(self._callback_url, requester)
+        # callback_url may contain format fields for filling in once the server
+        # is started and listening ports are known
+        callback_url = callback_url or self.CALLBACK_URL_FMT
+        callback_url = callback_url.format(
+            host=self._listen_host or "{host}",
+            port=self._listen_port or "{port}",
+        )
+        self.event_handler = UpnpEventHandler(callback_url, requester)
 
     async def start_server(self) -> None:
         """Start the HTTP server."""
@@ -154,14 +161,33 @@ class AiohttpNotifyServer:
                 self._listen_port,
                 error,
             )
+            raise
+
+        # All ports that the event server is listening on (maybe multiple IP stacks)
+        if self._server.sockets:
+            listen_ports = {
+                AddressFamily(sock.family): sock.getsockname()[0]
+                for sock in self._server.sockets
+            }
+        else:
+            _LOGGER.warning("No listening sockets for AiohttpNotifyServer")
+            listen_ports = {}
+
+        # Set event_handler's listen_ports  for it to format the callback_url correctly
+        self.event_handler.listen_ports = listen_ports
 
     async def stop_server(self) -> None:
         """Stop the HTTP server."""
+        await self.event_handler.async_unsubscribe_all()
+        self.event_handler.listen_ports = {}
+
         if self._aiohttp_server:
             await self._aiohttp_server.shutdown(10)
+            self._aiohttp_server = None
 
         if self._server:
             self._server.close()
+            self._server = None
 
     async def _handle_request(self, request: Any) -> aiohttp.web.Response:
         """Handle incoming requests."""
@@ -169,6 +195,10 @@ class AiohttpNotifyServer:
         if request.method != "NOTIFY":
             _LOGGER.debug("Not notify")
             return aiohttp.web.Response(status=405)
+
+        if not self.event_handler:
+            _LOGGER.debug("Event handler not created yet")
+            return aiohttp.web.Response(status=503, reason="Server not fully started")
 
         headers = request.headers
         body = await request.text()

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -16,14 +16,11 @@ from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 from async_upnp_client import UpnpDevice, UpnpFactory, UpnpService, UpnpStateVariable
 from async_upnp_client.advertisement import UpnpAdvertisementListener
-from async_upnp_client.aiohttp import (
-    AiohttpNotifyServer,
-    AiohttpRequester,
-    get_local_ip,
-)
+from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
 from async_upnp_client.ssdp import SSDP_ST_ALL
+from async_upnp_client.utils import get_local_ip
 
 logging.basicConfig()
 _LOGGER = logging.getLogger("upnp-client")

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -9,7 +9,6 @@ import logging
 import operator
 import sys
 import time
-import urllib.parse
 from datetime import datetime
 from ipaddress import ip_address
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
@@ -20,7 +19,6 @@ from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
 from async_upnp_client.ssdp import SSDP_ST_ALL
-from async_upnp_client.utils import get_local_ip
 
 logging.basicConfig()
 _LOGGER = logging.getLogger("upnp-client")
@@ -29,8 +27,6 @@ _LOGGER_LIB = logging.getLogger("async_upnp_client")
 _LOGGER_LIB.setLevel(logging.ERROR)
 _LOGGER_TRAFFIC = logging.getLogger("async_upnp_client.traffic")
 _LOGGER_TRAFFIC.setLevel(logging.ERROR)
-
-DEFAULT_PORT = 11302
 
 
 parser = argparse.ArgumentParser(description="upnp_client")
@@ -99,21 +95,20 @@ def get_timestamp() -> Union[str, float]:
     return time.time()
 
 
-def bind_host_port() -> Tuple[str, int]:
+def bind_host_port() -> Tuple[Optional[str], int]:
     """Determine listening host/port."""
     bind = args.bind
 
     if not bind:
-        # figure out listening host ourselves
-        target_url = args.device
-        parsed = urllib.parse.urlparse(target_url)
-        target_host = parsed.hostname
-        bind = get_local_ip(target_host)
+        # Listen on any address, on a random port
+        return None, 0
 
-    if ":" not in bind:
-        bind = bind + ":" + str(DEFAULT_PORT)
+    if ":" in bind:
+        host, port = bind.split(":")
+    else:
+        host = bind
+        port = 0
 
-    host, port = bind.split(":")
     return host, int(port)
 
 

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -242,7 +242,7 @@ class UpnpEventHandler:
         headers = {
             "HOST": urllib.parse.urlparse(service.event_sub_url).netloc,
             "SID": sid,
-            "TIMEOUT": "Second-" + str(timeout.seconds),
+            "TIMEOUT": "Second-" + str(timeout.total_seconds()),
         }
         response_status, response_headers, _ = await self._requester.async_http_request(
             "SUBSCRIBE", service.event_sub_url, headers

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping as abcMapping
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta, timezone
 import socket
+from socket import AddressFamily  # pylint: disable=no-name-in-module
 from typing import Any, Callable, Dict, Generator, Mapping, Optional, Tuple
 from urllib.parse import urljoin, urlsplit
 
@@ -199,7 +200,7 @@ def get_local_ip(target_url: Optional[str] = None) -> str:
 
 async def async_get_local_ip(
     target_url: Optional[str] = None, loop: Optional[asyncio.AbstractEventLoop] = None
-) -> Tuple[socket.AddressFamily, str]:
+) -> Tuple[AddressFamily, str]:
     """Try to get the local IP of this machine, used to talk to target_url."""
     target_addr = _target_url_to_addr(target_url)
     loop = loop or asyncio.get_running_loop()

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 """Utils for async_upnp_client."""
 
+import asyncio
 import re
 from collections.abc import Mapping as abcMapping
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, Generator, Mapping, Optional
-from urllib.parse import urljoin
+import socket
+from typing import Any, Callable, Dict, Generator, Mapping, Optional, Tuple
+from urllib.parse import urljoin, urlsplit
 
 from voluptuous import Invalid
+
+EXTERNAL_IP = "1.1.1.1"
+EXTERNAL_PORT = 80
 
 
 class CaseInsensitiveDict(MutableMapping):
@@ -161,3 +166,53 @@ def parse_date_time(value: str) -> Any:
         if re.match(pattern, value):
             return parser(value)
     raise ValueError("Unknown date/time: " + value)
+
+
+def _target_url_to_addr(target_url: Optional[str]) -> Tuple[str, int]:
+    """Resolve target_url into an address usable for get_local_ip."""
+    if target_url:
+        if "//" not in target_url:
+            # Make sure urllib can work with target_url to get the host
+            target_url = "//" + target_url
+        target_url_split = urlsplit(target_url)
+        target_host = target_url_split.hostname or EXTERNAL_IP
+        target_port = target_url_split.port or EXTERNAL_PORT
+    else:
+        target_host = EXTERNAL_IP
+        target_port = EXTERNAL_PORT
+
+    return target_host, target_port
+
+
+def get_local_ip(target_url: Optional[str] = None) -> str:
+    """Try to get the local IP of this machine, used to talk to target_url."""
+    target_addr = _target_url_to_addr(target_url)
+
+    try:
+        temp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        temp_sock.connect(target_addr)
+        local_ip: str = temp_sock.getsockname()[0]
+        return local_ip
+    finally:
+        temp_sock.close()
+
+
+async def async_get_local_ip(
+    target_url: Optional[str] = None, loop: Optional[asyncio.AbstractEventLoop] = None
+) -> Tuple[socket.AddressFamily, str]:
+    """Try to get the local IP of this machine, used to talk to target_url."""
+    target_addr = _target_url_to_addr(target_url)
+    loop = loop or asyncio.get_running_loop()
+
+    # Create a UDP connection to the target. This won't cause any network
+    # traffic but will assign a local IP to the socket.
+    transport, _ = await loop.create_datagram_endpoint(
+        asyncio.protocols.DatagramProtocol, remote_addr=target_addr
+    )
+
+    try:
+        sock = transport.get_extra_info("socket")
+        sockname = sock.getsockname()
+        return sock.family, sockname[0]
+    finally:
+        transport.close()

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,5 +1,7 @@
 """Unit tests for aiohttp."""
 
+from socket import AddressFamily
+
 import pytest
 
 from async_upnp_client.aiohttp import AiohttpNotifyServer
@@ -42,6 +44,10 @@ class TestAiohttpNotifyServer:
         assert server._aiohttp_server is not None
         assert server._server is not None
         assert len(server.event_handler.listen_ports) >= 1
+        for family, port in server.event_handler.listen_ports.items():
+            assert family in (AddressFamily.AF_INET, AddressFamily.AF_INET6)
+            assert isinstance(port, int)
+            assert 1 <= port <= 65535
         addr_family, host = await async_get_local_ip()
         port = server.event_handler.listen_ports[addr_family]
         expect_callback_url = "http://{host}:{port}/notify".format(host=host, port=port)

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,0 +1,60 @@
+"""Unit tests for aiohttp."""
+
+import pytest
+
+from async_upnp_client.aiohttp import AiohttpNotifyServer
+from async_upnp_client.utils import async_get_local_ip
+
+from .upnp_test_requester import RESPONSE_MAP, UpnpTestRequester
+
+
+class TestAiohttpNotifyServer:
+    """Tests for AiohttpNotifyServer."""
+
+    def test_init(self):
+        """Test initialization of an AiohttpNotifyServer."""
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        server = AiohttpNotifyServer(requester)
+        assert server._loop is not None
+        assert server._listen_host is None
+        assert server._listen_port == 0
+        with pytest.raises(ValueError, match=r"callback_url format.* port"):
+            server.callback_url
+        assert server._aiohttp_server is None
+        assert server._server is None
+        assert server.event_handler is not None
+
+        server = AiohttpNotifyServer(requester, 80, "localhost")
+        assert server._listen_host == "localhost"
+        assert server._listen_port == 80
+        assert server.callback_url == "http://localhost:80/notify"
+
+        server = AiohttpNotifyServer(requester, 80, "localhost", "http://1.2.3.4:88")
+        assert server.callback_url == "http://1.2.3.4:88"
+
+    @pytest.mark.asyncio
+    async def test_start_server(self):
+        """Test start_server creates internal servers on appropriate addresses."""
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        server = AiohttpNotifyServer(requester)
+        assert server.event_handler.listen_ports == {}
+        await server.start_server()
+        assert server._aiohttp_server is not None
+        assert server._server is not None
+        assert len(server.event_handler.listen_ports) >= 1
+        addr_family, host = await async_get_local_ip()
+        port = server.event_handler.listen_ports[addr_family]
+        expect_callback_url = "http://{host}:{port}/notify".format(host=host, port=port)
+        assert server.callback_url == expect_callback_url
+
+    @pytest.mark.asyncio
+    async def test_stop_server(self):
+        """Test stop_server deletes internal servers."""
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        server = AiohttpNotifyServer(requester)
+        await server.start_server()
+        await server.stop_server()
+        assert server.event_handler is not None
+        assert server.event_handler.listen_ports == {}
+        assert server._aiohttp_server is None
+        assert server._server is None

--- a/tests/test_upnp_client.py
+++ b/tests/test_upnp_client.py
@@ -2,6 +2,7 @@
 """Unit tests for upnp_client."""
 
 from datetime import datetime, timedelta
+import socket
 from typing import List, Mapping
 
 import defusedxml.ElementTree as ET
@@ -532,6 +533,22 @@ class TestUpnpEventHandler:
         assert success is True
         assert sid == "uuid:dummy"
         assert timeout == timedelta(seconds=300)
+        callback_url = await event_handler.async_callback_url_for_service(service)
+        assert callback_url == "http://localhost:11302"
+
+    @pytest.mark.asyncio
+    async def test_deferred_callback_url(self):
+        """Test creating a UpnpEventHandler with unspecified host and port."""
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        factory = UpnpFactory(requester)
+        device = await factory.async_create_device("http://localhost:1234/dmr")
+        event_handler = UpnpEventHandler(
+            "http://{host}:{port}", requester, {socket.AF_INET: 11302}
+        )
+
+        service = device.service("urn:schemas-upnp-org:service:RenderingControl:1")
+        callback_url = await event_handler.async_callback_url_for_service(service)
+        assert callback_url == "http://127.0.0.1:11302"
 
     @pytest.mark.asyncio
     async def test_subscribe_renew(self):


### PR DESCRIPTION
Defer determining the callback URLs for event subscriptions until subscription time. The callback URL can have `{host}` and `{port}` formatting placeholders that will be filled in when an event subscription is created. This allows using a random high port for the `AiohttpNotifyServer`, and also allows choosing the correct IP address when multiple network interfaces are available.