### PR TITLE
Typo: DlanOrgFlags -> DlnaOrgFlags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.18.1 (unreleased)
 
+- Rename `profiles.dlna.DlanOrgFlags` to `DlnaOrgFlags` to fix a typo (@chishm)
 
 0.18.0 (2021-05-23)
 

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -53,7 +53,7 @@ class DlnaOrgPs(Enum):
     NORMAL = 1
 
 
-class DlanOrgFlags(Enum):
+class DlnaOrgFlags(Enum):
     """
     DLNA.ORG_FLAGS flags.
 


### PR DESCRIPTION
This is a super minor change, but fixes a typo that keeps bugging me.