### PR TITLE
Automatic service resubscriptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changes
 - Defer event callback URL determination until event subscriptions are created (@chishm)
 - Add `UpnpDevice.icons` and `UpnpProfileDevice.icon` to get URLs to device icons (@chishm)
 - Add more non-strict parsing of action responses (#68)
+- asyncio and aiohttp exceptions are wrapped in exceptions derived from `UpnpError` to hide implementation details and make catching easier (@chishm)
+- `UpnpProfileDevice` can resubscribe to services automatically, using an asyncio task (@chishm)
 
 
 0.18.0 (2021-05-23)

--- a/async_upnp_client/__init__.py
+++ b/async_upnp_client/__init__.py
@@ -4,10 +4,10 @@
 from async_upnp_client.advertisement import UpnpAdvertisementListener  # noqa: F401
 from async_upnp_client.client import UpnpAction  # noqa: F401
 from async_upnp_client.client import UpnpDevice  # noqa: F401
-from async_upnp_client.client import UpnpError  # noqa: F401
 from async_upnp_client.client import UpnpRequester  # noqa: F401
 from async_upnp_client.client import UpnpService  # noqa: F401
 from async_upnp_client.client import UpnpStateVariable  # noqa: F401
-from async_upnp_client.client import UpnpValueError  # noqa: F401
 from async_upnp_client.client_factory import UpnpFactory  # noqa: F401
+from async_upnp_client.exceptions import UpnpError  # noqa: F401
+from async_upnp_client.exceptions import UpnpValueError  # noqa: F401
 from async_upnp_client.event_handler import UpnpEventHandler  # noqa: F401

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -90,7 +90,7 @@ class AiohttpSessionRequester(UpnpRequester):
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[str] = None,
         body_type: str = "text",
-    ) -> Tuple[int, Mapping, Union[str, bytes, None]]:
+    ) -> Tuple[int, Mapping[str, str], Union[str, bytes, None]]:
         """Do a HTTP request."""
         # pylint: disable=too-many-arguments
         req_headers = {**self._http_headers, **(headers or {})}

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -53,7 +53,7 @@ class UpnpRequester:
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[str] = None,
         body_type: str = "text",
-    ) -> Tuple[int, Mapping, Union[str, bytes, None]]:
+    ) -> Tuple[int, Mapping[str, str], Union[str, bytes, None]]:
         """
         Do a HTTP request.
 
@@ -100,7 +100,7 @@ class UpnpRequester:
         headers: Optional[Mapping[str, str]] = None,
         body: Optional[str] = None,
         body_type: str = "text",
-    ) -> Tuple[int, Mapping, Union[str, bytes, None]]:
+    ) -> Tuple[int, Mapping[str, str], Union[str, bytes, None]]:
         """Actually do a HTTP request."""
         # pylint: disable=too-many-arguments
         raise NotImplementedError()

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -31,6 +31,7 @@ from async_upnp_client.const import (
     ServiceInfo,
     StateVariableInfo,
 )
+from async_upnp_client.exceptions import UpnpError, UpnpValueError
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER_TRAFFIC_UPNP = logging.getLogger("async_upnp_client.traffic.upnp")
@@ -104,18 +105,6 @@ class UpnpRequester:
         """Actually do a HTTP request."""
         # pylint: disable=too-many-arguments
         raise NotImplementedError()
-
-
-class UpnpError(Exception):
-    """UpnpError."""
-
-
-class UpnpValueError(UpnpError):
-    """Invalid value error."""
-
-    def __init__(self, name: str, value: Any) -> None:
-        """Initialize."""
-        super().__init__("Invalid value for %s: '%s'" % (name, value))
 
 
 class UpnpDevice:

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -323,7 +323,15 @@ class UpnpEventHandler:
         """Unsubscribe from a UpnpService."""
         sid, service = self._sid_and_service(service_or_sid)
 
-        _LOGGER.debug("Unsubscribing from: %s, device: %s", service, service.device)
+        _LOGGER.debug(
+            "Unsubscribing from SID: %s, service: %s device: %s",
+            sid,
+            service,
+            service.device,
+        )
+
+        # Remove registration before potential device errors
+        del self._subscriptions[sid]
 
         # do UNSUBSCRIBE request
         headers = {
@@ -339,9 +347,6 @@ class UpnpEventHandler:
             _LOGGER.debug("Did not receive 200, but %s", response_status)
             raise UpnpResponseError(status=response_status, headers=response_headers)
 
-        # remove registration
-        if sid in self._subscriptions:
-            del self._subscriptions[sid]
         return sid
 
     async def async_unsubscribe_all(self) -> None:

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -6,7 +6,6 @@ import logging
 import urllib.parse
 from datetime import datetime, timedelta
 from http import HTTPStatus
-import socket
 from socket import AddressFamily  # pylint: disable=no-name-in-module
 from typing import Dict, Mapping, NamedTuple, Optional, Tuple
 
@@ -67,7 +66,7 @@ class UpnpEventHandler:
         """
         if not self._listen_ip:
             self._listen_ip = get_local_ip()
-        port = self.listen_ports.get(socket.AF_INET)
+        port = self.listen_ports.get(AddressFamily.AF_INET)
         if not port and "{port}" in self._callback_url:
             raise ValueError("callback_url format requires a listening port")
         return self._callback_url.format(host=self._listen_ip, port=port)

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """UPnP event handler module."""
 
+import asyncio
 import logging
 import urllib.parse
 from datetime import datetime, timedelta
@@ -284,9 +285,10 @@ class UpnpEventHandler:
 
     async def async_resubscribe_all(self) -> None:
         """Renew all current subscription."""
-        for entry in self._subscriptions.values():
-            service = entry.service
-            await self.async_resubscribe(service)
+        await asyncio.gather(
+            *(self.async_resubscribe(entry.service)
+              for entry in self._subscriptions.values())
+        )
 
     async def async_unsubscribe(
         self, service: "UpnpService"
@@ -321,6 +323,6 @@ class UpnpEventHandler:
     async def async_unsubscribe_all(self) -> None:
         """Unsubscribe all subscriptions."""
         services = self._subscriptions.copy()
-        for entry in services.values():
-            service = entry.service
-            await self.async_unsubscribe(service)
+        await asyncio.gather(
+            *(self.async_unsubscribe(entry.service) for entry in services.values())
+        )

--- a/async_upnp_client/exceptions.py
+++ b/async_upnp_client/exceptions.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Exceptions raised by async_upnp_client."""
+
+import asyncio
+from typing import Any, Optional
+
+import aiohttp
+
+# pylint: disable=too-many-ancestors
+
+
+class UpnpError(Exception):
+    """UpnpError."""
+
+
+class UpnpContentError(UpnpError):
+    """Content of UPnP response is invalid."""
+
+
+class UpnpValueError(UpnpContentError):
+    """Invalid value error."""
+
+    def __init__(self, name: str, value: Any) -> None:
+        """Initialize."""
+        super().__init__("Invalid value for %s: '%s'" % (name, value))
+        self.name = name
+        self.value = value
+
+
+class UpnpSIDError(UpnpContentError):
+    """Missing Subscription Identifier from response."""
+
+
+class UpnpCommunicationError(UpnpError, aiohttp.ClientError):
+    """Error occurred while communicating with the UPnP device ."""
+
+
+class UpnpResponseError(UpnpCommunicationError):
+    """HTTP error code returned by the UPnP device."""
+
+    def __init__(
+        self, status: int, headers: Optional[aiohttp.typedefs.LooseHeaders] = None
+    ) -> None:
+        """Initialize."""
+        super().__init__("Did not receive HTTP 200 but {}".format(status))
+        self.status = status
+        self.headers = headers
+
+
+class UpnpClientResponseError(aiohttp.ClientResponseError, UpnpResponseError):
+    """HTTP response error with more details from aiohttp."""
+
+
+class UpnpConnectionError(UpnpCommunicationError, aiohttp.ClientConnectionError):
+    """Error in the underlying connection to the UPnP device.
+
+    This could indicate that the device is offline.
+    """
+
+
+class UpnpConnectionTimeoutError(
+    UpnpConnectionError, aiohttp.ServerTimeoutError, asyncio.TimeoutError
+):
+    """Timeout while communicating with the device."""
+
+
+class UpnpServerError(UpnpError):
+    """Error with a local server."""
+
+
+class UpnpServerOSError(UpnpServerError, OSError):
+    """System-related error when starting a local server."""
+
+    def __init___(self, errno: int, strerror: str) -> None:
+        """Initialize simplified version of OSError."""
+        super().__init__(errno, strerror)
+        self.errno = errno
+        self.strerror = strerror

--- a/async_upnp_client/profiles/profile.py
+++ b/async_upnp_client/profiles/profile.py
@@ -344,6 +344,11 @@ class UpnpProfileDevice:
                     sid,
                 )
 
+    @property
+    def is_subscribed(self) -> bool:
+        """Get current service subscription state."""
+        return bool(self._subscriptions)
+
     def _on_event(
         self, service: UpnpService, state_variables: Sequence[UpnpStateVariable]
     ) -> None:

--- a/async_upnp_client/profiles/profile.py
+++ b/async_upnp_client/profiles/profile.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """UPnP base-profile module."""
 
+import asyncio
 import logging
 from datetime import timedelta
 from ipaddress import IPv4Address
@@ -224,8 +225,18 @@ class UpnpProfileDevice:
         return min(timeouts)
 
     async def async_unsubscribe_services(self) -> None:
-        """Unsubscribe from all subscribed services."""
-        await self._event_handler.async_unsubscribe_all()
+        """Unsubscribe from all of our subscribed services."""
+        for service in self.device.services.values():
+            try:
+                await self._event_handler.async_unsubscribe(service)
+            except UpnpError as err:
+                _LOGGER.debug("Failed unsubscribing from: %s, reason: %s", service, err)
+            except KeyError:
+                _LOGGER.warning(
+                    "%s was already unsubscribed. AiohttpNotifyServer was "
+                    "probably stopped before we could unsubscribe.",
+                    service,
+                )
 
     def _on_event(
         self, service: UpnpService, state_variables: Sequence[UpnpStateVariable]

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -1,8 +1,14 @@
 """Unit tests for profile."""
 
+import asyncio
+from datetime import timedelta
+import time
+from unittest.mock import Mock
+
 import pytest  # type: ignore
 
 from async_upnp_client import UpnpEventHandler, UpnpFactory
+from async_upnp_client.exceptions import UpnpCommunicationError, UpnpConnectionError
 from async_upnp_client.profiles.dlna import DmrDevice
 
 from ..upnp_test_requester import RESPONSE_MAP, UpnpTestRequester
@@ -46,5 +52,171 @@ class TestUpnpProfileDevice:
 
         assert profile.icon == "http://localhost:1234/device_icon_120.png"
 
+    @pytest.mark.asyncio
+    async def test_subscribe_manual_resubscribe(self):
+        """Test subscribing, resub, unsub, without auto_resubscribe."""
+        now = time.monotonic()
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        factory = UpnpFactory(requester)
+        device = await factory.async_create_device("http://localhost:1234/dmr")
+        event_handler = UpnpEventHandler("http://localhost:11302", requester)
+        profile = DmrDevice(device, event_handler=event_handler)
 
-# TODO: Test resubscribe
+        # Test subscription
+        timeout = await profile.async_subscribe_services(auto_resubscribe=False)
+        assert timeout is not None
+        # Timeout incorporates time tolerance, and is minimal renewal time
+        assert timedelta(seconds=(149 - 60)) <= timeout <= timedelta(seconds=(151 - 60))
+
+        assert set(profile._subscriptions.keys()) == {
+            "uuid:dummy-avt1",
+            "uuid:dummy",
+        }
+
+        # 2 timeouts, ~ 150 and ~ 300 seconds
+        timeouts = sorted(profile._subscriptions.values())
+        assert timeouts[0] == pytest.approx(now + 150, abs=1)
+        assert timeouts[1] == pytest.approx(now + 300, abs=1)
+
+        # Tweak timeouts to check resubscription did something
+        requester.response_map[
+            ("SUBSCRIBE", "http://localhost:1234/upnp/event/RenderingControl1")
+        ][1]["timeout"] = "Second-90"
+
+        # Check subscriptions again, now timeouts should have changed
+        timeout = await profile.async_subscribe_services(auto_resubscribe=False)
+        assert timeout is not None
+        assert timedelta(seconds=(89 - 60)) <= timeout <= timedelta(seconds=(91 - 60))
+        assert set(profile._subscriptions.keys()) == {
+            "uuid:dummy-avt1",
+            "uuid:dummy",
+        }
+        timeouts = sorted(profile._subscriptions.values())
+        assert timeouts[0] == pytest.approx(now + 90, abs=1)
+        assert timeouts[1] == pytest.approx(now + 150, abs=1)
+
+        # Test unsubscription
+        await profile.async_unsubscribe_services()
+        assert profile._subscriptions == {}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_auto_resubscribe(self):
+        """Test subscribing, resub, unsub, with auto_resubscribe."""
+        now = time.monotonic()
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        factory = UpnpFactory(requester)
+        device = await factory.async_create_device("http://localhost:1234/dmr")
+        event_handler = UpnpEventHandler("http://localhost:11302", requester)
+        profile = DmrDevice(device, event_handler=event_handler)
+
+        # Tweak timeouts to get a resubscription in a time suitable for testing.
+        # Resubscription tolerance (60 seconds) + 1 second to get set up
+        requester.response_map[
+            ("SUBSCRIBE", "http://localhost:1234/upnp/event/RenderingControl1")
+        ][1]["timeout"] = "Second-61"
+
+        # Test subscription
+        timeout = await profile.async_subscribe_services(auto_resubscribe=True)
+        assert timeout is None
+
+        # Check subscriptions are correct
+        assert set(profile._subscriptions.keys()) == {
+            "uuid:dummy-avt1",
+            "uuid:dummy",
+        }
+        timeouts = sorted(profile._subscriptions.values())
+        assert timeouts[0] == pytest.approx(now + 61, abs=1)
+        assert timeouts[1] == pytest.approx(now + 150, abs=1)
+
+        # Check task is running
+        assert isinstance(profile._resubscriber_task, asyncio.Task)
+        assert not profile._resubscriber_task.cancelled()
+        assert not profile._resubscriber_task.done()
+
+        # Re-tweak timeouts to check resubscription did something
+        requester.response_map[
+            ("SUBSCRIBE", "http://localhost:1234/upnp/event/AVTransport1")
+        ][1]["timeout"] = "Second-90"
+
+        # Wait for an auto-resubscribe
+        await asyncio.sleep(1.5)
+        now = time.monotonic()
+
+        # Check subscriptions and task again
+        assert set(profile._subscriptions.keys()) == {
+            "uuid:dummy-avt1",
+            "uuid:dummy",
+        }
+        timeouts = sorted(profile._subscriptions.values())
+        assert timeouts[0] == pytest.approx(now + 61, abs=1)
+        assert timeouts[1] == pytest.approx(now + 90, abs=1)
+        assert isinstance(profile._resubscriber_task, asyncio.Task)
+        assert not profile._resubscriber_task.cancelled()
+        assert not profile._resubscriber_task.done()
+
+        # Unsubscribe
+        await profile.async_unsubscribe_services()
+
+        # Task and subscriptions should be gone
+        assert profile._resubscriber_task is None
+        assert profile._subscriptions == {}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_fail(self):
+        """Test subscribing fails with UpnpError if device is offline."""
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        factory = UpnpFactory(requester)
+        device = await factory.async_create_device("http://localhost:1234/dmr")
+        event_handler = UpnpEventHandler("http://localhost:11302", requester)
+        profile = DmrDevice(device, event_handler=event_handler)
+
+        # First request is fine, 2nd raises an exception, when trying to subscribe
+        requester.exceptions.append(None)
+        requester.exceptions.append(UpnpCommunicationError())
+
+        with pytest.raises(UpnpCommunicationError):
+            await profile.async_subscribe_services(True)
+
+        # Subscriptions and resubscribe task should not exist
+        assert profile._subscriptions == {}
+        assert profile._resubscriber_task is None
+
+    @pytest.mark.asyncio
+    async def test_auto_resubscribe_fail(self):
+        """Test auto-resubscription when the device goes offline."""
+        requester = UpnpTestRequester(RESPONSE_MAP)
+        factory = UpnpFactory(requester)
+        device = await factory.async_create_device("http://localhost:1234/dmr")
+        event_handler = UpnpEventHandler("http://localhost:11302", requester)
+        profile = DmrDevice(device, event_handler=event_handler)
+        assert device.available is True
+
+        # Register an event handler
+        on_event_mock = Mock(return_value=None)
+        profile.on_event = on_event_mock
+
+        # Setup for auto-resubscription
+        requester.response_map[
+            ("SUBSCRIBE", "http://localhost:1234/upnp/event/RenderingControl1")
+        ][1]["timeout"] = "Second-61"
+        await profile.async_subscribe_services(auto_resubscribe=True)
+
+        # Exception raised when trying to resubscribe and subsequent retry subscribe
+        requester.exceptions.append(UpnpCommunicationError("resubscribe"))
+        requester.exceptions.append(UpnpConnectionError("subscribe"))
+
+        # Wait for an auto-resubscribe
+        await asyncio.sleep(1.5)
+
+        # Device should now be offline, and an event notification sent
+        assert device.available is False
+        on_event_mock.assert_called_once_with(
+            device.services["urn:schemas-upnp-org:service:RenderingControl:1"], []
+        )
+
+        # Unsubscribe should still work
+        await profile.async_unsubscribe_services()
+
+        # Task and subscriptions should be gone
+        assert profile._resubscriber_task is None
+        assert profile._subscriptions == {}

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -45,3 +45,6 @@ class TestUpnpProfileDevice:
         profile = DmrDevice(device, event_handler=event_handler)
 
         assert profile.icon == "http://localhost:1234/device_icon_120.png"
+
+
+# TODO: Test resubscribe

--- a/tests/test_upnp_client.py
+++ b/tests/test_upnp_client.py
@@ -545,9 +545,8 @@ class TestUpnpEventHandler:
         event_handler = UpnpEventHandler("http://localhost:11302", requester)
 
         service = device.service("urn:schemas-upnp-org:service:RenderingControl:1")
-        success, sid, timeout = await event_handler.async_subscribe(service)
+        sid, timeout = await event_handler.async_subscribe(service)
         assert event_handler.service_for_sid("uuid:dummy") == service
-        assert success is True
         assert sid == "uuid:dummy"
         assert timeout == timedelta(seconds=300)
         callback_url = await event_handler.async_callback_url_for_service(service)
@@ -576,15 +575,13 @@ class TestUpnpEventHandler:
         event_handler = UpnpEventHandler("http://localhost:11302", requester)
 
         service = device.service("urn:schemas-upnp-org:service:RenderingControl:1")
-        success, sid, timeout = await event_handler.async_subscribe(service)
-        assert success is True
+        sid, timeout = await event_handler.async_subscribe(service)
         assert sid == "uuid:dummy"
         assert event_handler.service_for_sid("uuid:dummy") == service
         assert timeout == timedelta(seconds=300)
 
-        success, sid, timeout = await event_handler.async_resubscribe(service)
+        sid, timeout = await event_handler.async_resubscribe(service)
         assert event_handler.service_for_sid("uuid:dummy") == service
-        assert success is True
         assert sid == "uuid:dummy"
         assert timeout == timedelta(seconds=300)
 
@@ -597,15 +594,13 @@ class TestUpnpEventHandler:
         event_handler = UpnpEventHandler("http://localhost:11302", requester)
 
         service = device.service("urn:schemas-upnp-org:service:RenderingControl:1")
-        success, sid, timeout = await event_handler.async_subscribe(service)
+        sid, timeout = await event_handler.async_subscribe(service)
         assert event_handler.service_for_sid("uuid:dummy") == service
-        assert success is True
         assert sid == "uuid:dummy"
         assert timeout == timedelta(seconds=300)
 
-        success, old_sid = await event_handler.async_unsubscribe(service)
+        old_sid = await event_handler.async_unsubscribe(service)
         assert event_handler.service_for_sid("uuid:dummy") is None
-        assert success is True
         assert old_sid == "uuid:dummy"
 
     @pytest.mark.asyncio

--- a/tests/upnp_test_requester.py
+++ b/tests/upnp_test_requester.py
@@ -3,13 +3,14 @@
 
 import asyncio
 import os.path
-from copy import copy
-from typing import Mapping, Optional, Tuple, Union
+from collections import deque
+from copy import deepcopy
+from typing import Any, Deque, Mapping, MutableMapping, Optional, Tuple, Union
 
 from async_upnp_client import UpnpRequester
 
 
-def read_file(filename) -> str:
+def read_file(filename: str) -> str:
     """Read file."""
     path = os.path.join("tests", "fixtures", filename)
     with open(path, "r") as file:
@@ -19,9 +20,18 @@ def read_file(filename) -> str:
 class UpnpTestRequester(UpnpRequester):
     """Test requester."""
 
-    def __init__(self, response_map) -> None:
+    def __init__(
+        self,
+        response_map: Mapping[
+            Tuple[str, str], Tuple[int, Mapping[Any, Any], Union[str, bytes, None]]
+        ],
+    ) -> None:
         """Class initializer."""
-        self._response_map = copy(response_map)
+        self.response_map: MutableMapping[
+            Tuple[str, str],
+            Tuple[int, MutableMapping[Any, Any], Union[str, bytes, None]],
+        ] = deepcopy(response_map)
+        self.exceptions: Deque[Optional[Exception]] = deque()
 
     async def async_do_http_request(
         self,
@@ -35,11 +45,16 @@ class UpnpTestRequester(UpnpRequester):
         # pylint: disable=too-many-arguments
         await asyncio.sleep(0.01)
 
-        key = (method, url)
-        if key not in self._response_map:
-            raise KeyError("Request not in response map")
+        if self.exceptions:
+            exception = self.exceptions.popleft()
+            if exception is not None:
+                raise exception
 
-        return self._response_map[key]
+        key = (method, url)
+        if key not in self.response_map:
+            raise KeyError(f"Request not in response map: {key}")
+
+        return self.response_map[key]
 
 
 RESPONSE_MAP = {
@@ -59,9 +74,19 @@ RESPONSE_MAP = {
         {"sid": "uuid:dummy", "timeout": "Second-300"},
         "",
     ),
+    ("SUBSCRIBE", "http://localhost:1234/upnp/event/AVTransport1"): (
+        200,
+        {"sid": "uuid:dummy-avt1", "timeout": "Second-150"},
+        "",
+    ),
     ("UNSUBSCRIBE", "http://localhost:1234/upnp/event/RenderingControl1"): (
         200,
         {"sid": "uuid:dummy"},
+        "",
+    ),
+    ("UNSUBSCRIBE", "http://localhost:1234/upnp/event/AVTransport1"): (
+        200,
+        {"sid": "uuid:dummy-avt1"},
         "",
     ),
 }

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py36, py37, py38, py39, flake8, pylint, typing, black
 
 [testenv]
-commands = py.test --cov=async_upnp_client --cov-report=term
+commands = py.test --cov=async_upnp_client --cov-report=term {posargs}
 deps =
     pytest
     pytest-asyncio


### PR DESCRIPTION
Service subscriptions can be automatically resubscribed by an `asyncio.Task` created by `UpnpProfileDevice`. Because exceptions can't be easily raised across tasks, device errors are reported via `on_event` with an empty `state_variable` list.

I've also changed how exceptions are raised, to hide implementation details from callers of the library, and to make the exceptions easier to catch.

I've updated the unit tests to cover service subscriptions, but I haven't tested this with a real device just yet. I wanted to let you review the changes while I do that testing.