### PR TITLE
Allow for overriding the `target` in `ssdp.SSDPListener.async_search()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 0.20.0 (unreleased)
 
 - Clean up `UpnpRequester`: Remove `body_type` parameter
+- Allow for overriding the `target` in `ssdp.SSDPListener.async_search()`
 
 
 0.19.1 (2021-07-21)

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -42,7 +42,6 @@ class UpnpAdvertisementListener:
         self.target_ip = target_ip or IPv4Address(SSDP_IP_V4)
         self.source_ip = source_ip or get_source_ip_from_target_ip(self.target_ip)
         self._loop: AbstractEventLoop = loop or asyncio.get_event_loop()
-
         self._transport: Optional[asyncio.BaseTransport] = None
 
     async def _on_data(

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -2,10 +2,16 @@
 """Constants module."""
 
 from datetime import date, datetime, time
-from typing import Callable, List, Mapping, NamedTuple, Optional, Sequence
+from ipaddress import IPv4Address, IPv6Address
+from typing import Callable, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
 from xml.etree import ElementTree as ET
 
 from async_upnp_client.utils import parse_date_time, require_tzinfo
+
+IPvXAddress = Union[IPv4Address, IPv6Address]
+AddressTupleV4Type = Tuple[str, int]
+AddressTupleV6Type = Tuple[str, int, int, int]
+AddressTupleVXType = Union[AddressTupleV4Type, AddressTupleV6Type]
 
 NS = {
     "soap_envelope": "http://schemas.xmlsoap.org/soap/envelope/",

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -8,11 +8,12 @@ from asyncio import BaseProtocol, BaseTransport, DatagramTransport
 from asyncio.events import AbstractEventLoop
 from datetime import datetime
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Awaitable, Callable, MutableMapping, Optional, Tuple, Union, cast
+from typing import Awaitable, Callable, MutableMapping, Optional, Tuple, cast
 from urllib.parse import urlsplit, urlunsplit
 
 from aiohttp.http_parser import HeadersParser
 
+from async_upnp_client.const import AddressTupleV6Type, AddressTupleVXType, IPvXAddress
 from async_upnp_client.utils import CaseInsensitiveDict
 
 SSDP_PORT = 1900
@@ -32,11 +33,6 @@ SSDP_BYEBYE = "ssdp:byebye"
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER_TRAFFIC_SSDP = logging.getLogger("async_upnp_client.traffic.ssdp")
-
-IPvXAddress = Union[IPv4Address, IPv6Address]
-AddressTupleV4Type = Tuple[str, int]
-AddressTupleV6Type = Tuple[str, int, int, int]
-AddressTupleVXType = Union[AddressTupleV4Type, AddressTupleV6Type]
 
 
 def get_host_string(addr: AddressTupleVXType) -> str:


### PR DESCRIPTION
Allow for overriding the `target` in `ssdp.SSDPListener.async_search()`. This is a change for home assistant to allow sending the search packet to the global broadcast address as well, used here: https://github.com/home-assistant/core/blob/c6a2e247fee794024158c7f1c9cb0576ca0a9fcf/homeassistant/components/ssdp/__init__.py#L249

I do not know whether the filter at https://github.com/StevenLooman/async_upnp_client/blob/a9a2d93393acb4d0917c7cf8aee8c113f8e70891/async_upnp_client/search.py#L73 will work properly. Though the search packet sent is using the multicast target, like `pysonos` does at https://github.com/amelchio/pysonos/blob/d4329b4abb657d106394ae69357805269708c996/pysonos/discovery.py#L120.

Unfortunately, I don't have a device which requires sending to the broadcast address, or even responds to it.