### PR TITLE
Wrap ElementTree.ParseError in a UpnpError type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.19.3 (unreleased)
 
+- Wrap XML `ParseError` in an error type derived from it and `UpnpError` too (@chishm)
 
 0.19.2 (2021-08-04)
 

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -28,6 +28,7 @@ from async_upnp_client.const import (
     StateVariableInfo,
     StateVariableTypeInfo,
 )
+from async_upnp_client.exceptions import UpnpXmlParseError
 from async_upnp_client.utils import absolute_url
 
 _LOGGER = logging.getLogger(__name__)
@@ -354,4 +355,4 @@ class UpnpFactory:
             return element
         except ET.ParseError as err:
             _LOGGER.debug("Unable to parse XML: %s\nXML:\n%s", err, description)
-            raise
+            raise UpnpXmlParseError(err) from err

--- a/async_upnp_client/exceptions.py
+++ b/async_upnp_client/exceptions.py
@@ -3,6 +3,7 @@
 
 import asyncio
 from typing import Any, Optional
+from xml.etree import ElementTree as ET
 
 import aiohttp
 
@@ -15,6 +16,16 @@ class UpnpError(Exception):
 
 class UpnpContentError(UpnpError):
     """Content of UPnP response is invalid."""
+
+
+class UpnpXmlParseError(UpnpError, ET.ParseError):
+    """UPnP response is not valid XML."""
+
+    def __init__(self, orig_err: ET.ParseError) -> None:
+        """Initialize from original ParseError, to match it."""
+        super().__init__(str(orig_err))
+        self.code = orig_err.code
+        self.position = orig_err.position
 
 
 class UpnpValueError(UpnpContentError):


### PR DESCRIPTION
Here's an exception type that I missed earlier. Wrapping `ET.ParseError` allows program code to catch `UpnpError` and handle (in the same way as an off device) the case where a device is giving invalid responses.