### PR TITLE
Allow passing a target to SSDPListener

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+0.20.0 (2021-08-17)
+
+- Breaking change: Calling `async_start` on `SSDPListener` no longer calls `async_search` immediately. (#77) @bdraco
+- Breaking change: The `target_ip` argument of `search.SSDPListener` has been dropped and replaced with `target` which takes a `AddressTupleVXType` (#77) @bdraco
+- Breaking change: The `target_ip` argument of `search.async_search` has been dropped and replaced with `target` which takes a `AddressTupleVXType` (#77) @bdraco
+
+
 0.19.2 (2021-08-04)
 
 - Clean up `UpnpRequester`: Remove `body_type` parameter

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -18,7 +18,7 @@ from async_upnp_client.advertisement import UpnpAdvertisementListener
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
-from async_upnp_client.ssdp import SSDP_PORT, SSDP_ST_ALL
+from async_upnp_client.ssdp import SSDP_PORT, SSDP_ST_ALL, AddressTupleVXType
 
 logging.basicConfig()
 _LOGGER = logging.getLogger("upnp-client")
@@ -300,7 +300,10 @@ async def search(search_args: Any) -> None:
     if source_ip:
         source_ip = ip_address(source_ip)
     if target_ip:
-        target = (target_ip, int(target_port) or SSDP_PORT)
+        target: Optional[AddressTupleVXType] = (
+            target_ip,
+            int(target_port) or SSDP_PORT,
+        )
     else:
         target = None
 

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -87,7 +87,7 @@ class SSDPListener:  # pylint: disable=too-many-arguments,too-many-instance-attr
                 self._target = (SSDP_IP_V6, SSDP_PORT)
             else:
                 self._target = (SSDP_IP_V4, SSDP_PORT)
-                
+
         if self.source_ip is None:
             self.source_ip = get_source_ip_from_target_ip(self._target[0])
 

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -4,13 +4,14 @@ import asyncio
 import logging
 from asyncio import DatagramTransport
 from asyncio.events import AbstractEventLoop
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import ip_address, IPv4Address, IPv6Address
 from typing import Awaitable, Callable, Mapping, MutableMapping, Optional
 
 from async_upnp_client.ssdp import (
     SSDP_IP_V4,
     SSDP_IP_V6,
     SSDP_MX,
+    SSDP_PORT,
     SSDP_ST_ALL,
     SSDP_TARGET_V4,
     SSDP_TARGET_V6,
@@ -35,10 +36,9 @@ class SSDPListener:  # pylint: disable=too-many-arguments,too-many-instance-attr
         async_callback: Callable[[Mapping[str, str]], Awaitable],
         loop: Optional[AbstractEventLoop] = None,
         source_ip: Optional[IPvXAddress] = None,
-        target_ip: Optional[IPvXAddress] = None,
+        target: Optional[AddressTupleVXType] = None,
         timeout: int = SSDP_MX,
         service_type: str = SSDP_ST_ALL,
-        target: Optional[AddressTupleVXType] = None,
         async_connect_callback: Optional[Callable[[], Awaitable]] = None,
     ) -> None:
         """Init the ssdp listener class."""
@@ -46,23 +46,18 @@ class SSDPListener:  # pylint: disable=too-many-arguments,too-many-instance-attr
         self.async_connect_callback = async_connect_callback
         self.service_type = service_type
         self.source_ip = source_ip
-        self.target_ip = target_ip
-        self.target = target
         self.timeout = timeout
         self.loop = loop
+        self._target: Optional[AddressTupleVXType] = target
         self._target_host: Optional[str] = None
-        self._target_data: Optional[AddressTupleVXType] = None
-        self._target: Optional[AddressTupleVXType] = None
         self._transport: Optional[DatagramTransport] = None
 
     def async_search(
         self, override_target: Optional[AddressTupleVXType] = None
     ) -> None:
         """Start an SSDP search."""
-        assert self._target_data is not None, "Call async_start() first"
-        packet = build_ssdp_search_packet(
-            self._target_data, self.timeout, self.service_type
-        )
+        assert self._target_host is not None, "Call async_start() first"
+        packet = build_ssdp_search_packet(self._target, self.timeout, self.service_type)
         _LOGGER.debug("Sending M-SEARCH packet, transport: %s", self._transport)
         _LOGGER_TRAFFIC_SSDP.debug("Sending M-SEARCH packet: %s", packet)
         assert self._transport is not None
@@ -87,28 +82,23 @@ class SSDPListener:  # pylint: disable=too-many-arguments,too-many-instance-attr
 
     async def async_start(self) -> None:
         """Start the listener."""
-        if self.target_ip is None:
+        if self._target is None:
             if self.source_ip and self.source_ip.version == 6:
-                self.target_ip = IPv6Address(SSDP_IP_V6)
+                self._target = (SSDP_IP_V6, SSDP_PORT)
             else:
-                self.target_ip = IPv4Address(SSDP_IP_V4)
+                self._target = (SSDP_IP_V4, SSDP_PORT)
+                
         if self.source_ip is None:
-            self.source_ip = get_source_ip_from_target_ip(self.target_ip)
+            self.source_ip = get_source_ip_from_target_ip(self._target[0])
 
+        target_ip: IPvXAddress = ip_address(self._target[0])
         # We use the standard target in the data of the announce since
         # many implementations will ignore the request otherwise
-        if self.target:
-            self._target_data = self.target
-        elif self.target_ip.version == 6:
-            self._target_data = SSDP_TARGET_V6
-        else:
-            self._target_data = SSDP_TARGET_V4
-
-        sock, source, self._target = get_ssdp_socket(
-            self.source_ip, self.target_ip, port=self._target_data[1]
+        sock, source, _ = get_ssdp_socket(
+            self.source_ip, target_ip, port=self._target[1]
         )
 
-        if not self.target_ip.is_multicast:
+        if not target_ip.is_multicast:
             self._target_host = get_host_string(self._target)
         else:
             self._target_host = ""
@@ -135,7 +125,7 @@ async def async_search(
     service_type: str = SSDP_ST_ALL,
     source_ip: Optional[IPvXAddress] = None,
     loop: Optional[AbstractEventLoop] = None,
-    target_ip: Optional[IPvXAddress] = None,
+    target: Optional[AddressTupleVXType] = None,
 ) -> None:
     """Discover devices via SSDP."""
     # pylint: disable=too-many-arguments
@@ -150,7 +140,7 @@ async def async_search(
         async_callback,
         loop_,
         source_ip,
-        target_ip,
+        target,
         timeout,
         service_type,
         async_connect_callback=_async_connected,

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from asyncio import DatagramTransport
 from asyncio.events import AbstractEventLoop
-from ipaddress import ip_address, IPv4Address, IPv6Address
+from ipaddress import ip_address
 from typing import Awaitable, Callable, Mapping, MutableMapping, Optional
 
 from async_upnp_client.ssdp import (
@@ -13,8 +13,6 @@ from async_upnp_client.ssdp import (
     SSDP_MX,
     SSDP_PORT,
     SSDP_ST_ALL,
-    SSDP_TARGET_V4,
-    SSDP_TARGET_V6,
     AddressTupleVXType,
     IPvXAddress,
     SsdpProtocol,

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -84,7 +84,6 @@ class SSDPListener:  # pylint: disable=too-many-arguments,too-many-instance-attr
         self._transport = transport
         if self.async_connect_callback:
             await self.async_connect_callback()
-        self.async_search()
 
     async def async_start(self) -> None:
         """Start the listener."""
@@ -141,9 +140,20 @@ async def async_search(
     """Discover devices via SSDP."""
     # pylint: disable=too-many-arguments
     loop_: AbstractEventLoop = loop or asyncio.get_event_loop()
+    listener: Optional[SSDPListener] = None
+
+    async def _async_connected():
+        nonlocal listener
+        listener.async_search()
 
     listener = SSDPListener(
-        async_callback, loop_, source_ip, target_ip, timeout, service_type
+        async_callback,
+        loop_,
+        source_ip,
+        target_ip,
+        timeout,
+        service_type,
+        async_connect_callback=_async_connected,
     )
 
     await listener.async_start()

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -194,11 +194,14 @@ def get_source_ip_from_target_ip(target_ip: IPvXAddress) -> IPvXAddress:
 
 
 def get_ssdp_socket(
-    source_ip: IPvXAddress, target_ip: IPvXAddress
+    source_ip: IPvXAddress, target_ip: IPvXAddress, port: Optional[int] = None
 ) -> Tuple[socket.socket, AddressTupleVXType, AddressTupleVXType]:
     """Create a socket to listen on."""
     target = socket.getaddrinfo(
-        str(target_ip), SSDP_PORT, type=socket.SOCK_DGRAM, proto=socket.IPPROTO_UDP
+        str(target_ip),
+        port or SSDP_PORT,
+        type=socket.SOCK_DGRAM,
+        proto=socket.IPPROTO_UDP,
     )[0]
     source = socket.getaddrinfo(
         str(source_ip), 0, type=socket.SOCK_DGRAM, proto=socket.IPPROTO_UDP

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,7 @@
 """Unit tests for search."""
 
 from async_upnp_client.search import SSDPListener
+from async_upnp_client.ssdp import SSDP_IP_V4
 
 
 def test_create_ssdp_listener_with_alternate_target():
@@ -9,7 +10,7 @@ def test_create_ssdp_listener_with_alternate_target():
     async def _dummy_callback(*args):
         pass
 
-    yeelight_target = ("239.255.255.250", 1982)
+    yeelight_target = (SSDP_IP_V4, 1982)
     yeelight_service_type = "wifi_bulb"
     listener = SSDPListener(
         async_callback=_dummy_callback,
@@ -18,7 +19,7 @@ def test_create_ssdp_listener_with_alternate_target():
         target=yeelight_target,
     )
 
-    assert listener.target == yeelight_target
+    assert listener._target == yeelight_target
     assert listener.service_type == yeelight_service_type
     assert listener.async_callback == _dummy_callback
     assert listener.async_connect_callback == _dummy_callback

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,24 @@
+"""Unit tests for search."""
+
+from async_upnp_client.search import SSDPListener
+
+
+def test_create_ssdp_listener_with_alternate_target():
+    """Create a SSDPListener on an alternate target."""
+
+    async def _dummy_callback(*args):
+        pass
+
+    yeelight_target = ("239.255.255.250", 1982)
+    yeelight_service_type = "wifi_bulb"
+    listener = SSDPListener(
+        async_callback=_dummy_callback,
+        async_connect_callback=_dummy_callback,
+        service_type=yeelight_service_type,
+        target=yeelight_target,
+    )
+
+    assert listener.target == yeelight_target
+    assert listener.service_type == yeelight_service_type
+    assert listener.async_callback == _dummy_callback
+    assert listener.async_connect_callback == _dummy_callback

--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -1,9 +1,12 @@
 """Unit tests for discovery."""
+from ipaddress import IPv4Address
 from unittest.mock import ANY
 
 from async_upnp_client.ssdp import (
+    SSDP_PORT,
     build_ssdp_search_packet,
     decode_ssdp_packet,
+    get_ssdp_socket,
     is_valid_ssdp_packet,
 )
 
@@ -160,3 +163,20 @@ def test_decode_ssdp_packet_v6():
         "_udn": "uuid:...",
         "_timestamp": ANY,
     }
+
+
+def test_get_ssdp_socket():
+    """Test get_ssdp_socket accepts a port."""
+    # Without a port, should default to SSDP_PORT
+    _, source_info, target_info = get_ssdp_socket(
+        IPv4Address("127.0.0.1"), IPv4Address("127.0.0.1")
+    )
+    assert source_info == ("127.0.0.1", 0)
+    assert target_info == ("127.0.0.1", SSDP_PORT)
+
+    # With a port
+    _, source_info, target_info = get_ssdp_socket(
+        IPv4Address("127.0.0.1"), IPv4Address("127.0.0.1"), 1234
+    )
+    assert source_info == ("127.0.0.1", 0)
+    assert target_info == ("127.0.0.1", 1234)


### PR DESCRIPTION
Breaking change:

- Calling `async_start` on `SSDPListener` no longer calls
  `async_search` immediately.

- `search.SSDPListener`'s `target_ip` argument has been dropped and
   replaced with `target` which takes a `AddressTupleVXType`

- `search.async_search`'s `target_ip` argument has been dropped and
   replaced with `target` which takes a `AddressTupleVXType`

- Yeelights run discovery on an alternate port
  https://gitlab.com/stavros/python-yeelight/-/blob/master/yeelight/ssdp_discover.py#L24