### PR TITLE
Unified SsdpListener to do searches and listen for advertisements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 Changes
 =======
 
-0.20.1 (unreleased)
+0.21.0 (unreleased)
 
-- More pylint/mypy
+- Breaking change: Rename `advertisement.UpnpAdvertisementListener` to `advertisement.SsdpAdvertisementListener`
+- Breaking change: Rename `search.SSDPListener` to `search.SsdpSearchListener`
 
 
 0.20.0 (2021-08-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes
 - Breaking change: Rename `advertisement.UpnpAdvertisementListener` to `advertisement.SsdpAdvertisementListener`
 - Breaking change: Rename `search.SSDPListener` to `search.SsdpSearchListener`
 - Add `ssdp_listener.SsdpListener`, class to keep track of devices seen via SSDP advertisements and searches
+- Breaking change: `UpnpDevice.boot_id` and `UpnpDevice.config_id` have been moved to `UpnpDevice.ssdp_headers`, using the respecitive keys from the SSDP headers
 
 
 0.20.0 (2021-08-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 
 - Breaking change: Rename `advertisement.UpnpAdvertisementListener` to `advertisement.SsdpAdvertisementListener`
 - Breaking change: Rename `search.SSDPListener` to `search.SsdpSearchListener`
+- Add `ssdp_listener.SsdpListener`, class to keep track of devices seen via SSDP advertisements and searches
 
 
 0.20.0 (2021-08-17)

--- a/README.rst
+++ b/README.rst
@@ -24,16 +24,39 @@ Status
    :target: https://pypi.python.org/pypi/async_upnp_client
 
 
+General set up
+--------------
+
+The `UPnP Device Architecture <https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf>`_ document contains several sections describing different parts of the UPnP standard. These chapters/sections can mostly be mapped to the following modules:
+
+* Chapter 1 Discovery
+  * Section 1.1 SSDP: `async_upnp_client.ssdp`
+  * Section 1.2 Advertisement: `async_upnp_client.advertisement` provides basic functionality to receive advertisements.
+  * Section 1.3 Search: `async_upnp_client.search` provides basic functionality to do search requests and gather the responses.
+  * `async_upnp_client.ssdp_client` contains the `SsdpListener` which combines advertisements and search to get the known devices and provides callbacks on changes. It is meant as something which runs continuously to provide useful information about the SSDP-active devices.
+* Chapter 2 Description / Chapter 3 Control
+  * `async_upnp_client.client_factory`/`async_upnp_client.client` provide a series of classes to get information about the device/services using the 'description', and interact with these devices.
+* Chapter 4 Eventing
+  * `async_upnp_client.event_handler` provides functionality to handle events received from the device.
+
+There are several 'profiles' which a device can implement to provide a standard interface to talk to. Some of these profiles are added to this library. The following profiles are currently available:
+
+* Internet Gateway Device (IGD)
+  * `async_upnp_client.profiles.igd`
+* Digital Living Network Alliance (DLNA)
+  * `async_upnp_client.profiles.dlna`
+* Printers
+  * `async_upnp_client.profiles.printer`
+
+For examples on how to use `async_upnp_client`, see `examples`/ .
+
+Note that this library is most likely does not fully implement all functionality from the UPnP Device Architecture document and/or contains errors/bugs/mis-interpretations.
+
+
 Contributing
 ------------
 
 See `CONTRIBUTING.rst`.
-
-
-Usage
------
-
-See `examples/` for examples on how to use async_upnp_client.
 
 
 Development
@@ -163,13 +186,3 @@ An example of listening for advertisements, note that the program stays running 
         "_udn": "uuid:99cb221c-1f15-c620-dc29-395f415623c6",
         "_source": "advertisement"
     }
-
-
-
-Abstractions
-------------
-
-- `DLNA Digital Media Renderer` (DLNA DMR) devices
-  - Primarily built for use with `Home Assistant <https://github.com/home-assistant/home-assistant>`_, but might be useful in other projects too.
-- `Internet Gateway Devices` (IGD)
-- Printers

--- a/async_upnp_client/__init__.py
+++ b/async_upnp_client/__init__.py
@@ -12,3 +12,4 @@ from async_upnp_client.event_handler import UpnpEventHandler  # noqa: F401
 from async_upnp_client.exceptions import UpnpError  # noqa: F401
 from async_upnp_client.exceptions import UpnpValueError  # noqa: F401
 from async_upnp_client.search import SsdpSearchListener  # noqa: F401
+from async_upnp_client.ssdp_listener import SsdpListener  # noqa: F401

--- a/async_upnp_client/__init__.py
+++ b/async_upnp_client/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """UPnP module."""
 
-from async_upnp_client.advertisement import UpnpAdvertisementListener  # noqa: F401
+from async_upnp_client.advertisement import SsdpAdvertisementListener  # noqa: F401
 from async_upnp_client.client import UpnpAction  # noqa: F401
 from async_upnp_client.client import UpnpDevice  # noqa: F401
 from async_upnp_client.client import UpnpRequester  # noqa: F401
@@ -11,3 +11,4 @@ from async_upnp_client.client_factory import UpnpFactory  # noqa: F401
 from async_upnp_client.event_handler import UpnpEventHandler  # noqa: F401
 from async_upnp_client.exceptions import UpnpError  # noqa: F401
 from async_upnp_client.exceptions import UpnpValueError  # noqa: F401
+from async_upnp_client.search import SsdpSearchListener  # noqa: F401

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -6,7 +6,7 @@ import logging
 from asyncio.events import AbstractEventLoop
 from asyncio.transports import BaseTransport
 from ipaddress import IPv4Address
-from typing import Awaitable, Callable, MutableMapping, Optional
+from typing import Any, Awaitable, Callable, MutableMapping, Optional
 
 from async_upnp_client.const import NotificationSubType
 from async_upnp_client.ssdp import (
@@ -23,8 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER_TRAFFIC_SSDP = logging.getLogger("async_upnp_client.traffic.ssdp")
 
 
-class UpnpAdvertisementListener:
-    """UPnP Advertisement listener."""
+class SsdpAdvertisementListener:
+    """SSDP Advertisement listener."""
 
     def __init__(
         self,
@@ -45,12 +45,12 @@ class UpnpAdvertisementListener:
         self._loop: AbstractEventLoop = loop or asyncio.get_event_loop()
         self._transport: Optional[BaseTransport] = None
 
-    async def _on_data(
-        self, request_line: str, headers: MutableMapping[str, str]
+    async def _async_on_data(
+        self, request_line: str, headers: MutableMapping[str, Any]
     ) -> None:
         """Handle data."""
         _LOGGER_TRAFFIC_SSDP.debug(
-            "UpnpAdvertisementListener._on_data: %s, %s", request_line, headers
+            "SsdpAdvertisementListener._async_on_data: %s, %s", request_line, headers
         )
         if headers.get("MAN") == SSDP_DISCOVER:
             # Ignore discover packets.
@@ -91,7 +91,7 @@ class UpnpAdvertisementListener:
 
         # Create protocol and send discovery packet.
         self._transport, _ = await self._loop.create_datagram_endpoint(
-            lambda: SsdpProtocol(self._loop, on_data=self._on_data),
+            lambda: SsdpProtocol(self._loop, on_data=self._async_on_data),
             sock=sock,
         )
 

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -50,7 +50,7 @@ class SsdpAdvertisementListener:
             # Ignore discover packets.
             return
         if "NTS" not in headers:
-            _LOGGER.debug("Got unknown packet: %s, %s", request_line, headers)
+            _LOGGER.debug("Got non-advertisement packet: %s, %s", request_line, headers)
             return
 
         _LOGGER.debug("Received advertisement, USN: %s", headers.get("USN", "<no USN>"))

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -19,7 +19,6 @@ from async_upnp_client.ssdp import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER_TRAFFIC_SSDP = logging.getLogger("async_upnp_client.traffic.ssdp")
 
 
 class SsdpAdvertisementListener:
@@ -48,9 +47,6 @@ class SsdpAdvertisementListener:
         self, request_line: str, headers: MutableMapping[str, Any]
     ) -> None:
         """Handle data."""
-        _LOGGER_TRAFFIC_SSDP.debug(
-            "SsdpAdvertisementListener._async_on_data: %s, %s", request_line, headers
-        )
         if headers.get("MAN") == SSDP_DISCOVER:
             # Ignore discover packets.
             return
@@ -58,11 +54,7 @@ class SsdpAdvertisementListener:
             _LOGGER.debug("Got unknown packet: %s, %s", request_line, headers)
             return
 
-        _LOGGER.debug(
-            "Received advertisement, request line: %s, headers: %s",
-            request_line,
-            headers,
-        )
+        _LOGGER.debug("Received advertisement, USN: %s", headers.get("USN", "<no USN>"))
 
         headers["_source"] = SsdpSource.ADVERTISEMENT
         notification_sub_type = headers["NTS"]

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -6,13 +6,14 @@ import logging
 from asyncio.events import AbstractEventLoop
 from asyncio.transports import BaseTransport
 from ipaddress import IPv4Address
-from typing import Any, Awaitable, Callable, MutableMapping, Optional
+from typing import Awaitable, Callable, Optional
 
 from async_upnp_client.const import NotificationSubType, SsdpSource
 from async_upnp_client.ssdp import (
     SSDP_DISCOVER,
     SSDP_IP_V4,
     IPvXAddress,
+    SsdpHeaders,
     SsdpProtocol,
     get_source_ip_from_target_ip,
     get_ssdp_socket,
@@ -26,9 +27,9 @@ class SsdpAdvertisementListener:
 
     def __init__(
         self,
-        on_alive: Optional[Callable[[MutableMapping[str, str]], Awaitable]] = None,
-        on_byebye: Optional[Callable[[MutableMapping[str, str]], Awaitable]] = None,
-        on_update: Optional[Callable[[MutableMapping[str, str]], Awaitable]] = None,
+        on_alive: Optional[Callable[[SsdpHeaders], Awaitable]] = None,
+        on_byebye: Optional[Callable[[SsdpHeaders], Awaitable]] = None,
+        on_update: Optional[Callable[[SsdpHeaders], Awaitable]] = None,
         source_ip: Optional[IPvXAddress] = None,
         target_ip: Optional[IPvXAddress] = None,
         loop: Optional[AbstractEventLoop] = None,
@@ -43,9 +44,7 @@ class SsdpAdvertisementListener:
         self._loop: AbstractEventLoop = loop or asyncio.get_event_loop()
         self._transport: Optional[BaseTransport] = None
 
-    async def _async_on_data(
-        self, request_line: str, headers: MutableMapping[str, Any]
-    ) -> None:
+    async def _async_on_data(self, request_line: str, headers: SsdpHeaders) -> None:
         """Handle data."""
         if headers.get("MAN") == SSDP_DISCOVER:
             # Ignore discover packets.

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -8,7 +8,7 @@ from asyncio.transports import BaseTransport
 from ipaddress import IPv4Address
 from typing import Any, Awaitable, Callable, MutableMapping, Optional
 
-from async_upnp_client.const import NotificationSubType
+from async_upnp_client.const import NotificationSubType, SsdpSource
 from async_upnp_client.ssdp import (
     SSDP_DISCOVER,
     SSDP_IP_V4,
@@ -16,7 +16,6 @@ from async_upnp_client.ssdp import (
     SsdpProtocol,
     get_source_ip_from_target_ip,
     get_ssdp_socket,
-    udn_from_headers,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,10 +64,7 @@ class SsdpAdvertisementListener:
             headers,
         )
 
-        udn = udn_from_headers(headers)
-        if udn:
-            headers["_udn"] = udn
-        headers["_source"] = "advertisement"
+        headers["_source"] = SsdpSource.ADVERTISEMENT
         notification_sub_type = headers["NTS"]
         if notification_sub_type == NotificationSubType.SSDP_ALIVE and self.on_alive:
             await self.on_alive(headers)

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -27,6 +27,8 @@ _LOGGER_TRAFFIC_UPNP = logging.getLogger("async_upnp_client.traffic.upnp")
 class AiohttpRequester(UpnpRequester):
     """Standard AioHttpUpnpRequester, to be used with UpnpFactory."""
 
+    # pylint: disable=too-few-public-methods
+
     def __init__(
         self, timeout: int = 5, http_headers: Optional[Mapping[str, str]] = None
     ) -> None:
@@ -94,6 +96,8 @@ class AiohttpSessionRequester(UpnpRequester):
 
     With pluggable session.
     """
+
+    # pylint: disable=too-few-public-methods
 
     def __init__(
         self,

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -21,6 +21,7 @@ from async_upnp_client.exceptions import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER_TRAFFIC_UPNP = logging.getLogger("async_upnp_client.traffic.upnp")
 
 
 class AiohttpRequester(UpnpRequester):
@@ -33,7 +34,7 @@ class AiohttpRequester(UpnpRequester):
         self._timeout = timeout
         self._http_headers = http_headers or {}
 
-    async def async_do_http_request(
+    async def async_http_request(
         self,
         method: str,
         url: str,
@@ -42,6 +43,16 @@ class AiohttpRequester(UpnpRequester):
     ) -> Tuple[int, Mapping, str]:
         """Do a HTTP request."""
         req_headers = {**self._http_headers, **(headers or {})}
+
+        _LOGGER_TRAFFIC_UPNP.debug(
+            "Sending request:\n%s %s\n%s\n%s\n",
+            method,
+            url,
+            "\n".join(
+                [key + ": " + value for key, value in (req_headers or {}).items()]
+            ),
+            body or "",
+        )
 
         try:
             async with async_timeout.timeout(self._timeout):
@@ -67,6 +78,13 @@ class AiohttpRequester(UpnpRequester):
         except aiohttp.ClientError as err:
             raise UpnpCommunicationError from err
 
+        _LOGGER_TRAFFIC_UPNP.debug(
+            "Got response:\n%s\n%s\n\n%s",
+            status,
+            "\n".join([key + ": " + value for key, value in resp_headers.items()]),
+            resp_body,
+        )
+
         return status, resp_headers, resp_body
 
 
@@ -90,7 +108,7 @@ class AiohttpSessionRequester(UpnpRequester):
         self._timeout = timeout
         self._http_headers = http_headers or {}
 
-    async def async_do_http_request(
+    async def async_http_request(
         self,
         method: str,
         url: str,
@@ -100,6 +118,16 @@ class AiohttpSessionRequester(UpnpRequester):
         """Do a HTTP request."""
         # pylint: disable=too-many-arguments
         req_headers = {**self._http_headers, **(headers or {})}
+
+        _LOGGER_TRAFFIC_UPNP.debug(
+            "Sending request:\n%s %s\n%s\n%s\n",
+            method,
+            url,
+            "\n".join(
+                [key + ": " + value for key, value in (req_headers or {}).items()]
+            ),
+            body or "",
+        )
 
         if self._with_sleep:
             await asyncio.sleep(0.01)
@@ -126,6 +154,13 @@ class AiohttpSessionRequester(UpnpRequester):
             ) from err
         except aiohttp.ClientError as err:
             raise UpnpCommunicationError from err
+
+        _LOGGER_TRAFFIC_UPNP.debug(
+            "Got response:\n%s\n%s\n\n%s",
+            status,
+            "\n".join([key + ": " + value for key, value in resp_headers.items()]),
+            resp_body,
+        )
 
         return status, resp_headers, resp_body
 
@@ -210,6 +245,15 @@ class AiohttpNotifyServer:
     async def _handle_request(self, request: Any) -> aiohttp.web.Response:
         """Handle incoming requests."""
         _LOGGER.debug("Received request: %s", request)
+
+        headers = request.headers
+        body = await request.text()
+        _LOGGER_TRAFFIC_UPNP.debug(
+            "Incoming request:\nNOTIFY\n%s\n\n%s",
+            "\n".join([key + ": " + value for key, value in headers.items()]),
+            body,
+        )
+
         if request.method != "NOTIFY":
             _LOGGER.debug("Not notify")
             return aiohttp.web.Response(status=405)
@@ -218,11 +262,10 @@ class AiohttpNotifyServer:
             _LOGGER.debug("Event handler not created yet")
             return aiohttp.web.Response(status=503, reason="Server not fully started")
 
-        headers = request.headers
-        body = await request.text()
-
         status = await self.event_handler.handle_notify(headers, body)
         _LOGGER.debug("NOTIFY response status: %s", status)
+        _LOGGER_TRAFFIC_UPNP.debug("Sending response: %s", status)
+
         return aiohttp.web.Response(status=status)
 
     @property

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -134,7 +134,7 @@ class AiohttpSessionRequester(UpnpRequester):
         )
 
         if self._with_sleep:
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0)
 
         try:
             async with async_timeout.timeout(self._timeout):

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -11,11 +11,12 @@ import sys
 import time
 from datetime import datetime
 from ipaddress import ip_address
-from typing import Any, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 from async_upnp_client import UpnpDevice, UpnpFactory, UpnpService, UpnpStateVariable
 from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
+from async_upnp_client.const import SsdpHeaders
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
 from async_upnp_client.ssdp import SSDP_PORT, SSDP_ST_ALL, AddressTupleVXType
@@ -307,9 +308,9 @@ async def search(search_args: Any) -> None:
     else:
         target = None
 
-    async def on_response(data: Mapping[str, Any]) -> None:
-        data = {key: str(value) for key, value in data.items()}
-        print(json.dumps(data, indent=pprint_indent))
+    async def on_response(headers: SsdpHeaders) -> None:
+        headers = {key: str(value) for key, value in headers.items()}
+        print(json.dumps(headers, indent=pprint_indent))
 
     await async_ssdp_search(
         service_type=service_type,
@@ -332,9 +333,9 @@ async def advertisements(advertisement_args: Any) -> None:
     if target_ip:
         target_ip = ip_address(target_ip)
 
-    async def on_notify(data: Mapping[str, Any]) -> None:
-        data = {key: str(value) for key, value in data.items()}
-        print(json.dumps(data, indent=pprint_indent))
+    async def on_notify(headers: SsdpHeaders) -> None:
+        headers = {key: str(value) for key, value in headers.items()}
+        print(json.dumps(headers, indent=pprint_indent))
 
     listener = SsdpAdvertisementListener(
         on_alive=on_notify,

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -14,7 +14,7 @@ from ipaddress import ip_address
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 from async_upnp_client import UpnpDevice, UpnpFactory, UpnpService, UpnpStateVariable
-from async_upnp_client.advertisement import UpnpAdvertisementListener
+from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
@@ -336,7 +336,7 @@ async def advertisements(advertisement_args: Any) -> None:
         data = {key: str(value) for key, value in data.items()}
         print(json.dumps(data, indent=pprint_indent))
 
-    listener = UpnpAdvertisementListener(
+    listener = SsdpAdvertisementListener(
         on_alive=on_notify,
         on_byebye=on_notify,
         on_update=on_notify,

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -3,6 +3,7 @@
 
 import logging
 import urllib.parse
+from abc import ABC
 from datetime import datetime, timezone
 from typing import (
     Any,
@@ -28,9 +29,11 @@ from async_upnp_client.const import (
     DeviceIcon,
     DeviceInfo,
     ServiceInfo,
+    SsdpHeaders,
     StateVariableInfo,
 )
 from async_upnp_client.exceptions import UpnpError, UpnpValueError, UpnpXmlParseError
+from async_upnp_client.utils import CaseInsensitiveDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,12 +41,14 @@ _LOGGER = logging.getLogger(__name__)
 EventCallbackType = Callable[["UpnpService", Sequence["UpnpStateVariable"]], None]
 
 
-class UpnpRequester:
+class UpnpRequester(ABC):
     """
     Abstract base class used for performing async HTTP requests.
 
     Implement method async_do_http_request() in your concrete class.
     """
+
+    # pylint: disable=too-few-public-methods
 
     async def async_http_request(
         self,
@@ -85,7 +90,7 @@ class UpnpDevice:
             service.device = self
 
         # SSDP headers.
-        self.ssdp_headers: Mapping[str, Any] = {}
+        self.ssdp_headers: SsdpHeaders = CaseInsensitiveDict()
 
         # Just initialized, mark available.
         self.available = True

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -105,8 +105,6 @@ class UpnpDevice:
         requester: UpnpRequester,
         device_info: DeviceInfo,
         services: Sequence["UpnpService"],
-        boot_id: Optional[str] = None,
-        config_id: Optional[str] = None,
     ) -> None:
         """Initialize."""
         # pylint: disable=too-many-arguments
@@ -118,8 +116,8 @@ class UpnpDevice:
         for service in services:
             service.device = self
 
-        self.boot_id: Optional[str] = boot_id
-        self.config_id: Optional[str] = config_id
+        # SSDP headers.
+        self.ssdp_headers: Mapping[str, Any] = {}
 
         # Just initialized, mark available.
         self.available = True
@@ -127,16 +125,7 @@ class UpnpDevice:
     def reinit(self, device: "UpnpDevice") -> None:
         """Reinitialize self from another device."""
         self.device_info = device.device_info
-
-        self.services = device.services
-        for service in self.services.values():
-            service.device = self
-
-        # XXX TODO: What about event handlers on the services?
-        # XXX TODO: Ssdp 'settings' in own dict? Or bind SsdpDevice?
-
-        self.boot_id = device.boot_id
-        self.config_id = device.config_id
+        self.ssdp_headers = device.ssdp_headers
 
     @property
     def name(self) -> str:

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -111,7 +111,7 @@ class UpnpDevice:
         """Initialize."""
         # pylint: disable=too-many-arguments
         self.requester = requester
-        self._device_info = device_info
+        self.device_info = device_info
         self.services = {service.service_type: service for service in services}
 
         # bind services to ourselves
@@ -124,65 +124,79 @@ class UpnpDevice:
         # Just initialized, mark available.
         self.available = True
 
+    def reinit(self, device: "UpnpDevice") -> None:
+        """Reinitialize self from another device."""
+        self.device_info = device.device_info
+
+        self.services = device.services
+        for service in self.services.values():
+            service.device = self
+
+        # XXX TODO: What about event handlers on the services?
+        # XXX TODO: Ssdp 'settings' in own dict? Or bind SsdpDevice?
+
+        self.boot_id = device.boot_id
+        self.config_id = device.config_id
+
     @property
     def name(self) -> str:
         """Get the name of this device."""
-        return self._device_info.friendly_name
+        return self.device_info.friendly_name
 
     @property
     def friendly_name(self) -> str:
         """Get the friendly name of this device, alias for name."""
-        return self._device_info.friendly_name
+        return self.device_info.friendly_name
 
     @property
     def manufacturer(self) -> str:
         """Get the manufacturer of this device."""
-        return self._device_info.manufacturer
+        return self.device_info.manufacturer
 
     @property
     def model_description(self) -> Optional[str]:
         """Get the model description of this device."""
-        return self._device_info.model_description
+        return self.device_info.model_description
 
     @property
     def model_name(self) -> str:
         """Get the model name of this device."""
-        return self._device_info.model_name
+        return self.device_info.model_name
 
     @property
     def model_number(self) -> Optional[str]:
         """Get the model number of this device."""
-        return self._device_info.model_number
+        return self.device_info.model_number
 
     @property
     def serial_number(self) -> Optional[str]:
         """Get the serial number of this device."""
-        return self._device_info.serial_number
+        return self.device_info.serial_number
 
     @property
     def udn(self) -> str:
         """Get UDN of this device."""
-        return self._device_info.udn
+        return self.device_info.udn
 
     @property
     def device_url(self) -> str:
         """Get the URL of this device."""
-        return self._device_info.url
+        return self.device_info.url
 
     @property
     def device_type(self) -> str:
         """Get the device type of this device."""
-        return self._device_info.device_type
+        return self.device_info.device_type
 
     @property
     def icons(self) -> Sequence[DeviceIcon]:
         """Get the icons for this device."""
-        return self._device_info.icons
+        return self.device_info.icons
 
     @property
     def xml(self) -> ET.Element:
         """Get the XML description for this device."""
-        return self._device_info.xml
+        return self.device_info.xml
 
     def has_service(self, service_type: str) -> bool:
         """Check if service by service_type is available."""

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -33,7 +33,6 @@ from async_upnp_client.const import (
 from async_upnp_client.exceptions import UpnpError, UpnpValueError, UpnpXmlParseError
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER_TRAFFIC_UPNP = logging.getLogger("async_upnp_client.traffic.upnp")
 
 
 EventCallbackType = Callable[["UpnpService", Sequence["UpnpStateVariable"]], None]
@@ -63,37 +62,6 @@ class UpnpRequester:
 
         :return status code, headers, body
         """
-        # pylint: disable=too-many-arguments
-        _LOGGER_TRAFFIC_UPNP.debug(
-            "Sending request:\n%s %s\n%s\n%s\n",
-            method,
-            url,
-            "\n".join([key + ": " + value for key, value in (headers or {}).items()]),
-            body or "",
-        )
-        (
-            response_status,
-            response_headers,
-            response_body,
-        ) = await self.async_do_http_request(method, url, headers=headers, body=body)
-
-        _LOGGER_TRAFFIC_UPNP.debug(
-            "Got response:\n%s\n%s\n\n%s",
-            response_status,
-            "\n".join([key + ": " + value for key, value in response_headers.items()]),
-            response_body,
-        )
-
-        return response_status, response_headers, response_body
-
-    async def async_do_http_request(
-        self,
-        method: str,
-        url: str,
-        headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
-    ) -> Tuple[int, Mapping[str, str], str]:
-        """Actually do a HTTP request."""
         raise NotImplementedError()
 
 
@@ -125,7 +93,6 @@ class UpnpDevice:
     def reinit(self, device: "UpnpDevice") -> None:
         """Reinitialize self from another device."""
         self.device_info = device.device_info
-        self.ssdp_headers = device.ssdp_headers
 
     @property
     def name(self) -> str:

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -60,8 +60,6 @@ class UpnpFactory:
     async def async_create_device(
         self,
         description_url: str,
-        boot_id: Optional[str] = None,
-        config_id: Optional[str] = None,
     ) -> UpnpDevice:
         """Create a UpnpDevice, with all of it UpnpServices."""
         _LOGGER.debug("Creating device, description_url: %s", description_url)
@@ -78,7 +76,7 @@ class UpnpFactory:
             service = await self.async_create_service(service_desc_xml, description_url)
             services.append(service)
 
-        return UpnpDevice(self.requester, device_desc, services, boot_id, config_id)
+        return UpnpDevice(self.requester, device_desc, services)
 
     def _device_parse_xml(
         self, device_description_xml: ET.Element, description_url: str

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -7,7 +7,7 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import Callable, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
 from xml.etree import ElementTree as ET
 
-from async_upnp_client.utils import parse_date_time, require_tzinfo
+from async_upnp_client.utils import CaseInsensitiveDict, parse_date_time, require_tzinfo
 
 IPvXAddress = Union[IPv4Address, IPv6Address]
 AddressTupleV4Type = Tuple[str, int]
@@ -164,6 +164,7 @@ StateVariableInfo = NamedTuple(
 )
 
 # Headers
+SsdpHeaders = CaseInsensitiveDict
 NotificationType = str  # NT header
 UniqueServiceName = str  # USN header
 SearchTarget = str  # ST header

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -176,3 +176,10 @@ class NotificationSubType(str, enum.Enum):
     SSDP_ALIVE = "ssdp:alive"
     SSDP_BYEBYE = "ssdp:byebye"
     SSDP_UPDATE = "ssdp:update"
+
+
+class SsdpSource(str, enum.Enum):
+    """SSDP source."""
+
+    ADVERTISEMENT = "advertisement"
+    SEARCH = "search"

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Constants module."""
 
-import enum
 from datetime import date, datetime, time
+from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 from typing import Callable, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
 from xml.etree import ElementTree as ET
@@ -168,9 +168,10 @@ NotificationType = str  # NT header
 UniqueServiceName = str  # USN header
 SearchTarget = str  # ST header
 UniqueDeviceName = str  # UDN
+DeviceOrServiceType = str
 
 
-class NotificationSubType(str, enum.Enum):
+class NotificationSubType(str, Enum):
     """NTS header."""
 
     SSDP_ALIVE = "ssdp:alive"
@@ -178,8 +179,13 @@ class NotificationSubType(str, enum.Enum):
     SSDP_UPDATE = "ssdp:update"
 
 
-class SsdpSource(str, enum.Enum):
+class SsdpSource(str, Enum):
     """SSDP source."""
 
     ADVERTISEMENT = "advertisement"
     SEARCH = "search"
+
+    # More detailed.
+    ADVERTISEMENT_ALIVE = "advertisement_alive"
+    ADVERTISEMENT_BYEBYE = "advertisement_byebye"
+    ADVERTISEMENT_UPDATE = "advertisement_update"

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -4,10 +4,21 @@
 from datetime import date, datetime, time
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
-from typing import Callable, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    List,
+    Mapping,
+    MutableMapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 from xml.etree import ElementTree as ET
 
-from async_upnp_client.utils import CaseInsensitiveDict, parse_date_time, require_tzinfo
+from async_upnp_client.utils import parse_date_time, require_tzinfo
 
 IPvXAddress = Union[IPv4Address, IPv6Address]
 AddressTupleV4Type = Tuple[str, int]
@@ -164,7 +175,7 @@ StateVariableInfo = NamedTuple(
 )
 
 # Headers
-SsdpHeaders = CaseInsensitiveDict
+SsdpHeaders = MutableMapping[str, Any]
 NotificationType = str  # NT header
 UniqueServiceName = str  # USN header
 SearchTarget = str  # ST header

--- a/async_upnp_client/description_cache.py
+++ b/async_upnp_client/description_cache.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Description cache."""
+
+import asyncio
+import logging
+from typing import Optional
+
+import aiohttp
+
+from async_upnp_client.client import UpnpRequester
+from async_upnp_client.exceptions import UpnpResponseError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DescriptionCache:
+    """Cache for descriptions (xml)."""
+
+    def __init__(self, requester: UpnpRequester):
+        """Initialize."""
+        self._requester = requester
+        self._cache: dict[str, Optional[str]] = {}
+
+    async def async_get_description(self, location: str) -> Optional[str]:
+        """Get a description, either from cache or download it."""
+        if location is None:
+            return None
+        if location not in self._cache:
+            try:
+                self._cache[location] = await self._async_fetch_description(location)
+            except Exception:  # pylint: disable=broad-except
+                # If it fails, cache the failure so we do not keep trying over and over
+                self._cache[location] = None
+                _LOGGER.exception("Failed to fetch description from: %s", location)
+
+        return self._cache[location]
+
+    async def _async_fetch_description(self, location: str) -> Optional[str]:
+        """Download a description from location."""
+        try:
+            for _ in range(2):
+                status, headers, body = await self._requester.async_http_request(
+                    "GET", location
+                )
+                if status != 200:
+                    raise UpnpResponseError(status=status, headers=headers)
+                return body
+                # Samsung Smart TV sometimes returns an empty document the
+                # first time. Retry once.
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            _LOGGER.debug("Error fetching %s: %s", location, err)
+
+        return None

--- a/async_upnp_client/description_cache.py
+++ b/async_upnp_client/description_cache.py
@@ -57,7 +57,7 @@ class DescriptionCache:
         return self._cache_xml[location]
 
     async def async_get_description_dict(
-        self, location: str
+        self, location: Optional[str]
     ) -> Optional[Mapping[str, str]]:
         """Get a description as dict, either from cache or download it."""
         if location is None:

--- a/async_upnp_client/description_cache.py
+++ b/async_upnp_client/description_cache.py
@@ -3,14 +3,31 @@
 
 import asyncio
 import logging
-from typing import Optional
+from typing import Mapping, Optional
 
 import aiohttp
+import defusedxml.ElementTree as DET
 
 from async_upnp_client.client import UpnpRequester
 from async_upnp_client.exceptions import UpnpResponseError
+from async_upnp_client.utils import etree_to_dict
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _description_xml_to_dict(description_xml: str) -> Optional[Mapping[str, str]]:
+    """Convert description (XML) to dict."""
+    try:
+        tree = DET.fromstring(description_xml)
+    except DET.ParseError as err:
+        _LOGGER.debug("Error parsing %s: %s", description_xml, err)
+        return None
+
+    root = etree_to_dict(tree).get("root")
+    if root is None:
+        return None
+
+    return root.get("device")
 
 
 class DescriptionCache:
@@ -19,21 +36,48 @@ class DescriptionCache:
     def __init__(self, requester: UpnpRequester):
         """Initialize."""
         self._requester = requester
-        self._cache: dict[str, Optional[str]] = {}
+        self._cache_xml: dict[str, Optional[str]] = {}
+        self._cache_dict: dict[str, Optional[Mapping[str, str]]] = {}
 
-    async def async_get_description(self, location: str) -> Optional[str]:
-        """Get a description, either from cache or download it."""
+    async def async_get_description_xml(self, location: str) -> Optional[str]:
+        """Get a description as XML, either from cache or download it."""
         if location is None:
             return None
-        if location not in self._cache:
+
+        if location not in self._cache_xml:
             try:
-                self._cache[location] = await self._async_fetch_description(location)
+                self._cache_xml[location] = await self._async_fetch_description(
+                    location
+                )
             except Exception:  # pylint: disable=broad-except
                 # If it fails, cache the failure so we do not keep trying over and over
-                self._cache[location] = None
+                self._cache_xml[location] = None
                 _LOGGER.exception("Failed to fetch description from: %s", location)
 
-        return self._cache[location]
+        return self._cache_xml[location]
+
+    async def async_get_description_dict(
+        self, location: str
+    ) -> Optional[Mapping[str, str]]:
+        """Get a description as dict, either from cache or download it."""
+        if location is None:
+            return None
+
+        if location not in self._cache_dict:
+            description_xml = await self.async_get_description_xml(location)
+            if description_xml:
+                self._cache_dict[location] = _description_xml_to_dict(description_xml)
+            else:
+                self._cache_dict[location] = None
+
+        return self._cache_dict[location]
+
+    def uncache_description(self, location: str) -> None:
+        """Uncache a description."""
+        if location in self._cache_xml:
+            del self._cache_xml[location]
+        if location in self._cache_dict:
+            del self._cache_dict[location]
 
     async def _async_fetch_description(self, location: str) -> Optional[str]:
         """Download a description from location."""

--- a/async_upnp_client/device_updater.py
+++ b/async_upnp_client/device_updater.py
@@ -117,8 +117,8 @@ class DeviceUpdater:
     ) -> None:
         """Reinitialize device."""
         # pylint: disable=protected-access
-        _LOGGER.debug("Reinitializing device")
+        _LOGGER.debug("Reinitializing device, location: %s", location)
 
         new_device = await self._factory.async_create_device(location)
-        new_device.ssdp_headers = ssdp_headers
         self._device.reinit(new_device)
+        self._device.ssdp_headers = ssdp_headers

--- a/async_upnp_client/device_updater.py
+++ b/async_upnp_client/device_updater.py
@@ -2,9 +2,10 @@
 
 import logging
 from ipaddress import IPv4Address
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 from async_upnp_client import SsdpAdvertisementListener, UpnpDevice, UpnpFactory
+from async_upnp_client.const import SsdpHeaders
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class DeviceUpdater:
         _LOGGER.debug("Stop listening for notifications.")
         await self._listener.async_stop()
 
-    async def _on_alive(self, headers: Mapping[str, str]) -> None:
+    async def _on_alive(self, headers: SsdpHeaders) -> None:
         """Handle on alive."""
         # Ensure for root devices only.
         if headers.get("nt") != "upnp:rootdevice":
@@ -58,12 +59,12 @@ class DeviceUpdater:
         _LOGGER.debug("Handling alive: %s", headers)
         await self._async_handle_alive_update(headers)
 
-    async def _on_byebye(self, headers: Mapping[str, Any]) -> None:
+    async def _on_byebye(self, headers: SsdpHeaders) -> None:
         """Handle on byebye."""
         _LOGGER.debug("Handling on_byebye: %s", headers)
         self._device.available = False
 
-    async def _on_update(self, headers: Mapping[str, Any]) -> None:
+    async def _on_update(self, headers: SsdpHeaders) -> None:
         """Handle on update."""
         # Ensure for root devices only.
         if headers.get("nt") != "upnp:rootdevice":
@@ -76,7 +77,7 @@ class DeviceUpdater:
         _LOGGER.debug("Handling update: %s", headers)
         await self._async_handle_alive_update(headers)
 
-    async def _async_handle_alive_update(self, headers: Mapping[str, str]) -> None:
+    async def _async_handle_alive_update(self, headers: SsdpHeaders) -> None:
         """Handle on_alive or on_update."""
         do_reinit = False
 
@@ -112,9 +113,7 @@ class DeviceUpdater:
         # We heard from it, so mark it available.
         self._device.available = True
 
-    async def _reinit_device(
-        self, location: str, ssdp_headers: Mapping[str, Any]
-    ) -> None:
+    async def _reinit_device(self, location: str, ssdp_headers: SsdpHeaders) -> None:
         """Reinitialize device."""
         # pylint: disable=protected-access
         _LOGGER.debug("Reinitializing device, location: %s", location)

--- a/async_upnp_client/device_updater.py
+++ b/async_upnp_client/device_updater.py
@@ -4,7 +4,7 @@ import logging
 from ipaddress import IPv4Address
 from typing import Any, Mapping, Optional
 
-from async_upnp_client import UpnpAdvertisementListener, UpnpDevice, UpnpFactory
+from async_upnp_client import SsdpAdvertisementListener, UpnpDevice, UpnpFactory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class DeviceUpdater:
         """Initialize."""
         self._device = device
         self._factory = factory
-        self._listener = UpnpAdvertisementListener(
+        self._listener = SsdpAdvertisementListener(
             on_alive=self._on_alive,
             on_byebye=self._on_byebye,
             on_update=self._on_update,

--- a/async_upnp_client/device_updater.py
+++ b/async_upnp_client/device_updater.py
@@ -120,13 +120,7 @@ class DeviceUpdater:
         _LOGGER.debug("Reinitializing device")
 
         new_device = await self._factory.async_create_device(location)
+        new_device.boot_id = boot_id
+        new_device.config_id = config_id
 
-        self._device._device_info = new_device._device_info
-
-        # Copy new services and update the binding between the original device and new services.
-        self._device.services = new_device.services
-        for service in self._device.services.values():
-            service.device = self._device
-
-        self._device.boot_id = boot_id
-        self._device.config_id = config_id
+        self._device.reinit(new_device)

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -23,7 +23,6 @@ from async_upnp_client.exceptions import (
 from async_upnp_client.utils import async_get_local_ip, get_local_ip
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER_TRAFFIC_UPNP = logging.getLogger("async_upnp_client.traffic.upnp")
 
 
 class UpnpEventHandler:
@@ -134,13 +133,7 @@ class UpnpEventHandler:
     async def handle_notify(self, headers: Mapping[str, str], body: str) -> HTTPStatus:
         """Handle a NOTIFY request."""
         # ensure valid request
-        _LOGGER_TRAFFIC_UPNP.debug(
-            "Incoming request:\nNOTIFY\n%s\n\n%s",
-            "\n".join([key + ": " + value for key, value in headers.items()]),
-            body,
-        )
         if "NT" not in headers or "NTS" not in headers:
-            _LOGGER_TRAFFIC_UPNP.debug("Sending response: %s", HTTPStatus.BAD_REQUEST)
             return HTTPStatus.BAD_REQUEST
 
         if (
@@ -148,9 +141,6 @@ class UpnpEventHandler:
             or headers["NTS"] != "upnp:propchange"
             or "SID" not in headers
         ):
-            _LOGGER_TRAFFIC_UPNP.debug(
-                "Sending response: %s", HTTPStatus.PRECONDITION_FAILED
-            )
             return HTTPStatus.PRECONDITION_FAILED
 
         sid = headers["SID"]
@@ -165,7 +155,6 @@ class UpnpEventHandler:
                 body,
             )
 
-            _LOGGER_TRAFFIC_UPNP.debug("Sending response: %s", HTTPStatus.OK)
             return HTTPStatus.OK
 
         # decode event and send updates to service
@@ -181,7 +170,6 @@ class UpnpEventHandler:
         # send changes to service
         service.notify_changed_state_variables(changes)
 
-        _LOGGER_TRAFFIC_UPNP.debug("Sending response: %s", HTTPStatus.OK)
         return HTTPStatus.OK
 
     async def async_subscribe(

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -264,7 +264,7 @@ class DmrDevice(UpnpProfileDevice):
     def _on_event(
         self, service: UpnpService, state_variables: Sequence[UpnpStateVariable]
     ) -> None:
-        """State variable(s) changed, let home-assistant know."""
+        """State variable(s) changed, perform callback(s)."""
         # handle DLNA specific event
         for state_variable in state_variables:
             if state_variable.name == "LastChange":

--- a/async_upnp_client/profiles/profile.py
+++ b/async_upnp_client/profiles/profile.py
@@ -6,7 +6,7 @@ import logging
 import time
 from datetime import timedelta
 from ipaddress import IPv4Address
-from typing import Dict, List, Mapping, Optional, Sequence, Set
+from typing import Dict, List, Optional, Sequence, Set
 
 from async_upnp_client.client import (
     EventCallbackType,
@@ -15,6 +15,7 @@ from async_upnp_client.client import (
     UpnpService,
     UpnpStateVariable,
 )
+from async_upnp_client.const import SsdpHeaders
 from async_upnp_client.event_handler import UpnpEventHandler
 from async_upnp_client.exceptions import UpnpConnectionError, UpnpError
 from async_upnp_client.search import async_search
@@ -42,7 +43,7 @@ class UpnpProfileDevice:
     @classmethod
     async def async_search(
         cls, source_ip: Optional[IPv4Address] = None, timeout: int = SSDP_MX
-    ) -> Set[Mapping[str, str]]:
+    ) -> Set[SsdpHeaders]:
         """
         Search for this device type.
 
@@ -54,7 +55,7 @@ class UpnpProfileDevice:
         """
         responses = set()
 
-        async def on_response(data: Mapping[str, str]) -> None:
+        async def on_response(data: SsdpHeaders) -> None:
             if "st" in data and data["st"] in cls.DEVICE_TYPES:
                 responses.add(data)
 
@@ -65,7 +66,7 @@ class UpnpProfileDevice:
         return responses
 
     @classmethod
-    async def async_discover(cls) -> Set[Mapping[str, str]]:
+    async def async_discover(cls) -> Set[SsdpHeaders]:
         """Alias for async_search."""
         return await cls.async_search()
 

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -26,8 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER_TRAFFIC_SSDP = logging.getLogger("async_upnp_client.traffic.ssdp")
 
 
-class SSDPListener:  # pylint: disable=too-many-arguments,too-many-instance-attributes
-    """Class to listen for SSDP."""
+class SsdpSearchListener:  # pylint: disable=too-many-arguments,too-many-instance-attributes
+    """SSDP Search (response) listener."""
 
     def __init__(
         self,
@@ -129,14 +129,14 @@ async def async_search(
     """Discover devices via SSDP."""
     # pylint: disable=too-many-arguments
     loop_: AbstractEventLoop = loop or asyncio.get_event_loop()
-    listener: Optional[SSDPListener] = None
+    listener: Optional[SsdpSearchListener] = None
 
     async def _async_connected() -> None:
         nonlocal listener
         assert listener is not None
         listener.async_search()
 
-    listener = SSDPListener(
+    listener = SsdpSearchListener(
         async_callback,
         loop_,
         source_ip,

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -7,6 +7,7 @@ from asyncio.events import AbstractEventLoop
 from ipaddress import ip_address
 from typing import Awaitable, Callable, Mapping, MutableMapping, Optional
 
+from async_upnp_client.const import SsdpSource
 from async_upnp_client.ssdp import (
     SSDP_IP_V4,
     SSDP_IP_V6,
@@ -69,7 +70,7 @@ class SsdpSearchListener:  # pylint: disable=too-many-arguments,too-many-instanc
         _LOGGER.debug(
             "Received response, request line: %s, headers: %s", request_line, headers
         )
-        headers["_source"] = "search"
+        headers["_source"] = SsdpSource.SEARCH
         if self._target_host and self._target_host != headers["_host"]:
             return
         await self.async_callback(headers)

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -130,7 +130,7 @@ def decode_ssdp_packet(
         lines.append(b"")
 
     parsed_headers, _ = HeadersParser().parse_headers(lines)
-    headers = CaseInsensitiveDict(**dict(parsed_headers))
+    headers = CaseInsensitiveDict(parsed_headers)
 
     # adjust some headers
     if "location" in headers:

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -198,6 +198,13 @@ class SsdpProtocol(BaseProtocol):
         """Handle connection lost."""
         _LOGGER.debug("Lost connection, error: %s, transport: %s", exc, self.transport)
 
+    def send_ssdp_packet(self, packet: bytes, target: AddressTupleVXType) -> None:
+        """Send a SSDP packet."""
+        _LOGGER.debug("Sending M-SEARCH packet, transport: %s", self.transport)
+        _LOGGER_TRAFFIC_SSDP.debug("Sending M-SEARCH packet: %s", packet)
+        assert self.transport is not None
+        self.transport.sendto(packet, target)
+
 
 def get_source_ip_from_target_ip(target_ip: IPvXAddress) -> IPvXAddress:
     """Deduce a bind ip address from a target address potentially including scope."""

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -8,7 +8,7 @@ from asyncio import BaseProtocol, BaseTransport, DatagramTransport
 from asyncio.events import AbstractEventLoop
 from datetime import datetime
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Awaitable, Callable, Mapping, MutableMapping, Optional, Tuple, cast
+from typing import Awaitable, Callable, Optional, Tuple, cast
 from urllib.parse import urlsplit, urlunsplit
 
 from aiohttp.http_parser import HeadersParser
@@ -17,7 +17,7 @@ from async_upnp_client.const import (
     AddressTupleV6Type,
     AddressTupleVXType,
     IPvXAddress,
-    NotificationSubType,
+    SsdpHeaders,
     UniqueDeviceName,
 )
 from async_upnp_client.utils import CaseInsensitiveDict
@@ -35,11 +35,6 @@ SSDP_DISCOVER = '"ssdp:discover"'
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER_TRAFFIC_SSDP = logging.getLogger("async_upnp_client.traffic.ssdp")
-
-
-SSDP_ALIVE = NotificationSubType.SSDP_ALIVE
-SSDP_BYEBYE = NotificationSubType.SSDP_BYEBYE
-SSDP_UPDATE = NotificationSubType.SSDP_UPDATE
 
 
 def get_host_string(addr: AddressTupleVXType) -> str:
@@ -113,7 +108,7 @@ def is_valid_ssdp_packet(data: bytes) -> bool:
     )
 
 
-def udn_from_headers(headers: Mapping[str, str]) -> Optional[UniqueDeviceName]:
+def udn_from_headers(headers: SsdpHeaders) -> Optional[UniqueDeviceName]:
     """Get UDN from USN in headers."""
     if "usn" in headers and "uuid:" in headers["usn"]:
         parts = str(headers["usn"]).split("::")
@@ -161,7 +156,7 @@ class SsdpProtocol(BaseProtocol):
         self,
         loop: AbstractEventLoop,
         on_connect: Optional[Callable[[DatagramTransport], Awaitable]] = None,
-        on_data: Optional[Callable[[str, MutableMapping[str, str]], Awaitable]] = None,
+        on_data: Optional[Callable[[str, SsdpHeaders], Awaitable]] = None,
     ) -> None:
         """Initialize."""
         self.loop = loop

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -1,0 +1,422 @@
+"""SSDP Search + Advertisement listener, keeping track of known devices on the network."""
+
+import enum
+import logging
+import re
+from asyncio.events import AbstractEventLoop
+from datetime import datetime, timedelta
+from ipaddress import ip_address
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Union,
+)
+
+from async_upnp_client.advertisement import SsdpAdvertisementListener
+from async_upnp_client.const import (
+    AddressTupleVXType,
+    IPvXAddress,
+    NotificationSubType,
+    NotificationType,
+    SearchTarget,
+    UniqueDeviceName,
+)
+from async_upnp_client.search import SsdpSearchListener
+from async_upnp_client.ssdp import SSDP_IP_V4, SSDP_MX, SSDP_PORT, udn_from_headers
+from async_upnp_client.utils import CaseInsensitiveDict
+
+_LOGGER = logging.getLogger(__name__)
+CACHE_CONTROL_RE = re.compile(r"max-age\s*=\s*(\d+)")
+DEFAULT_MAX_AGE = timedelta(seconds=900)
+
+
+@enum.unique
+class SourceType(enum.Enum):
+    """Source of change."""
+
+    SEARCH = 0
+    ALIVE = 1
+    UPDATED = 2
+    BYEBYE = 3
+
+
+def valid_search_headers(headers: Mapping[str, Any]) -> bool:
+    """Validate if this search is usable."""
+    return "usn" in headers and "st" in headers
+
+
+def valid_advertisement_headers(headers: Mapping[str, Any]) -> bool:
+    """Validate if this advertisement is usable."""
+    return "usn" in headers and "nt" in headers and "nts" in headers
+
+
+def extract_valid_to(headers: Mapping[str, Any]) -> datetime:
+    """Extract/create valid to."""
+    match = CACHE_CONTROL_RE.search(headers.get("cache-controle", ""))
+    if match:
+        max_age = int(match[1])
+        uncache_after = timedelta(seconds=max_age)
+    else:
+        uncache_after = DEFAULT_MAX_AGE
+    return datetime.now() + uncache_after
+
+
+def headers_differ(
+    current_headers: Mapping[str, Any], new_headers: Mapping[str, Any]
+) -> bool:
+    """Compare headers to see if anything interesting has changed."""
+    current_filtered = {
+        key: value
+        for key, value in current_headers.items()
+        if not key.startswith("_") and key.lower() != "date"
+    }
+    new_filtered = {
+        key: value
+        for key, value in new_headers.items()
+        if not key.startswith("_") and key.lower() != "date"
+    }
+    if _LOGGER.level <= logging.DEBUG:
+        diff_values = {
+            k: (
+                current_filtered.get(k),
+                new_filtered.get(k),
+            )
+            for k in set(current_filtered).union(set(new_filtered))
+            if current_filtered.get(k) != new_filtered.get(k)
+        }
+        if current_filtered and diff_values:
+            _LOGGER.debug("Changed values: %s", diff_values)
+    return current_filtered != new_filtered
+
+
+class SsdpDevice:
+    """
+    SSDP Device.
+
+    Holds all known information about the device.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(
+        self,
+        udn: str,
+    ):
+        """Initialize."""
+        self.udn = udn
+        self.location: Optional[str] = None
+        self.last_seen: Optional[datetime] = None
+        self.valid_to: Optional[datetime] = None
+        self.device_types: set[str] = set()
+        self.service_types: set[str] = set()
+        self.search_headers: dict[NotificationType, CaseInsensitiveDict] = {}
+        self.advertisement_headers: dict[NotificationType, CaseInsensitiveDict] = {}
+        self.userdata: Any = None
+
+    def combined_headers(
+        self,
+        notification_type: Union[NotificationType, SearchTarget],
+    ) -> Mapping[str, Any]:
+        """Get combined headers from search and advertisement for a given NT."""
+        headers = dict(self.search_headers.get(notification_type, {}))
+        headers.update(self.advertisement_headers.get(notification_type, {}))
+        return headers
+
+    def __repr__(self) -> str:
+        """Return the representation."""
+        return f"<{type(self).__name__}({self.udn})>"
+
+
+def headers_differ_from_existing_advertisement(
+    ssdp_device: SsdpDevice, key: str, headers: Mapping[str, Any]
+) -> bool:
+    """Compare against existing search headers to see if anything interesting has changed."""
+    if key not in ssdp_device.advertisement_headers:
+        return False
+
+    current_headers = ssdp_device.advertisement_headers[key]
+    shared_keys = set(current_headers) - set(headers)
+
+    current_filtered = {
+        key: value for key, value in current_headers.items() if key in shared_keys
+    }
+    new_filtered = {key: value for key, value in headers.items() if key in shared_keys}
+    return headers_differ(current_filtered, new_filtered)
+
+
+def headers_differ_from_existing_search(
+    ssdp_device: SsdpDevice, key: str, headers: Mapping[str, Any]
+) -> bool:
+    """Compare against existing search headers to see if anything interesting has changed."""
+    if key not in ssdp_device.search_headers:
+        return False
+
+    current_headers = ssdp_device.search_headers[key]
+    shared_keys = set(current_headers).intersection(set(headers))
+
+    current_filtered = {
+        key: value for key, value in current_headers.items() if key in shared_keys
+    }
+    new_filtered = {key: value for key, value in headers.items() if key in shared_keys}
+    return headers_differ(current_filtered, new_filtered)
+
+
+class SsdpDeviceTracker:
+    """Device tracker."""
+
+    def __init__(self) -> None:
+        """Initialize."""
+        self.devices: dict[UniqueDeviceName, SsdpDevice] = {}
+
+    def see_search(
+        self, headers: Mapping[str, Any]
+    ) -> Tuple[bool, Optional[SsdpDevice], Optional[SearchTarget]]:
+        """See a device through a search."""
+        if not valid_search_headers(headers):
+            return False, None, None
+
+        udn = headers["_udn"]
+        is_new_device = udn not in self.devices
+
+        ssdp_device = self._see_device(headers)
+        if not ssdp_device:
+            return False, None, None
+
+        search_target = headers["ST"]
+        propagate = (
+            is_new_device
+            or headers_differ_from_existing_search(ssdp_device, search_target, headers)
+            or headers_differ_from_existing_advertisement(
+                ssdp_device, search_target, headers
+            )
+        )
+
+        # Update stored headers.
+        current_headers = ssdp_device.search_headers.setdefault(
+            search_target, CaseInsensitiveDict()
+        )
+        current_headers.clear()
+        current_headers.update(headers)
+
+        return propagate, ssdp_device, search_target
+
+    def see_advertisement(
+        self, headers: Mapping[str, Any]
+    ) -> Tuple[bool, Optional[SsdpDevice], Optional[NotificationType]]:
+        """See a device through an advertisement."""
+        if not valid_advertisement_headers(headers):
+            return False, None, None
+
+        udn = headers["_udn"]
+        is_new_device = udn not in self.devices
+
+        ssdp_device = self._see_device(headers)
+        if not ssdp_device:
+            return False, None, None
+
+        notification_type = headers["NT"]
+        notification_sub_type = headers["NTS"]
+        propagate = (
+            notification_sub_type == NotificationSubType.SSDP_UPDATE
+            or is_new_device
+            or headers_differ_from_existing_advertisement(
+                ssdp_device, notification_type, headers
+            )
+            or headers_differ_from_existing_search(
+                ssdp_device, notification_type, headers
+            )
+        )
+
+        # Update stored headers.
+        current_headers = ssdp_device.advertisement_headers.setdefault(
+            notification_type, CaseInsensitiveDict()
+        )
+        current_headers.clear()
+        current_headers.update(headers)
+
+        return propagate, ssdp_device, notification_type
+
+    def _see_device(self, headers: Mapping[str, Any]) -> Optional[SsdpDevice]:
+        """See a device through a search."""
+        udn = udn_from_headers(headers)
+        if not udn:
+            # Ignore broken devices.
+            return None
+
+        if udn not in self.devices:
+            # Create new device.
+            ssdp_device = SsdpDevice(udn)
+            _LOGGER.debug("See new device: %s", ssdp_device)
+            self.devices[udn] = ssdp_device
+        ssdp_device = self.devices[udn]
+
+        # Update device.
+        ssdp_device.location = headers["location"]
+        ssdp_device.last_seen = headers["_timestamp"]
+        ssdp_device.valid_to = extract_valid_to(headers)
+
+        # Purge any old devices.
+        self.purge_devices()
+
+        return ssdp_device
+
+    def unsee_advertisement(
+        self, headers: Mapping[str, Any]
+    ) -> Tuple[bool, Optional[SsdpDevice], Optional[NotificationType]]:
+        """Remove a device through an advertisement."""
+        if not valid_advertisement_headers(headers):
+            return False, None, None
+
+        udn = udn_from_headers(headers)
+        if not udn:
+            # Ignore broken devices.
+            return False, None, None
+
+        if udn not in self.devices:
+            return False, None, None
+
+        ssdp_device = self.devices[udn]
+        del self.devices[udn]
+
+        propagate = True  # Always true, if this is the 2nd unsee then device is already deleted.
+        notification_type = headers["NT"]
+        return propagate, ssdp_device, notification_type
+
+    def get_device(self, headers: Mapping[str, Any]) -> Optional[SsdpDevice]:
+        """Get a device from headers."""
+        if "usn" not in headers:
+            return None
+
+        udn = udn_from_headers(headers)
+        if not udn:
+            return None
+
+        return self.devices.get(udn)
+
+    def purge_devices(self, override_now: Optional[datetime] = None) -> None:
+        """Purge any devices for which the CACHE-CONTROL header is timed out."""
+        now = override_now or datetime.now()
+        to_remove = [
+            usn
+            for usn, device in self.devices.items()
+            if device.valid_to and now > device.valid_to
+        ]
+        for usn in to_remove:
+            del self.devices[usn]
+
+
+class SsdpListener:
+    """SSDP Search and Advertisement listener."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(
+        self,
+        callback: Callable[
+            [SsdpDevice, Union[NotificationType, SearchTarget], SourceType], Awaitable
+        ],
+        source_ip: Optional[IPvXAddress] = None,
+        target: Optional[AddressTupleVXType] = None,
+        loop: Optional[AbstractEventLoop] = None,
+        search_timeout: int = SSDP_MX,
+    ) -> None:
+        """Initialize."""
+        # pylint: disable=too-many-arguments
+        self.callback = callback
+        self.source_ip = source_ip
+        self.target: AddressTupleVXType = target or (
+            SSDP_IP_V4,
+            SSDP_PORT,
+        )
+        self.loop = loop
+        self.search_timeout = search_timeout
+        self._device_tracker = SsdpDeviceTracker()
+        self._advertisement_listener: Optional[SsdpAdvertisementListener] = None
+        self._search_listener: Optional[SsdpSearchListener] = None
+
+    async def async_start(self) -> None:
+        """Start search listener/advertisement listener."""
+        target_ip = ip_address(self.target[0])
+        self._advertisement_listener = SsdpAdvertisementListener(
+            on_alive=self._on_alive,
+            on_update=self._on_update,
+            on_byebye=self._on_byebye,
+            source_ip=self.source_ip,
+            target_ip=target_ip,
+            loop=self.loop,
+        )
+        await self._advertisement_listener.async_start()
+
+        self._search_listener = SsdpSearchListener(
+            self._on_search,
+            loop=self.loop,
+            source_ip=self.source_ip,
+            target=self.target,
+            timeout=self.search_timeout,
+        )
+        await self._search_listener.async_start()
+
+    async def async_stop(self) -> None:
+        """Stop scanner/listener."""
+        if self._advertisement_listener:
+            await self._advertisement_listener.async_stop()
+
+        if self._search_listener:
+            self._search_listener.async_stop()
+
+    def async_search(
+        self, override_target: Optional[AddressTupleVXType] = None
+    ) -> None:
+        """Send a SSDP Search packet."""
+        assert self._search_listener is not None, "Call async_start() first"
+        self._search_listener.async_search(override_target)
+
+    async def _on_search(self, headers: MutableMapping[str, str]) -> None:
+        """Search callback."""
+        propagate, ssdp_device, search_target = self._device_tracker.see_search(headers)
+
+        if propagate and ssdp_device and search_target:
+            await self.callback(ssdp_device, search_target, SourceType.SEARCH)
+
+    async def _on_alive(self, headers: MutableMapping[str, str]) -> None:
+        """On alive."""
+        (
+            propagate,
+            ssdp_device,
+            notification_type,
+        ) = self._device_tracker.see_advertisement(headers)
+
+        if propagate and ssdp_device and notification_type:
+            await self.callback(ssdp_device, notification_type, SourceType.ALIVE)
+
+    async def _on_byebye(self, headers: MutableMapping[str, str]) -> None:
+        """On byebye."""
+        (
+            propagate,
+            ssdp_device,
+            notification_type,
+        ) = self._device_tracker.unsee_advertisement(headers)
+
+        if propagate and ssdp_device and notification_type:
+            await self.callback(ssdp_device, notification_type, SourceType.BYEBYE)
+
+    async def _on_update(self, headers: MutableMapping[str, str]) -> None:
+        """On update."""
+        (
+            propagate,
+            ssdp_device,
+            notification_type,
+        ) = self._device_tracker.see_advertisement(headers)
+
+        if propagate and ssdp_device and notification_type:
+            await self.callback(ssdp_device, notification_type, SourceType.UPDATED)
+
+    @property
+    def devices(self) -> Mapping[str, SsdpDevice]:
+        """Get the known devices."""
+        return self._device_tracker.devices

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -57,7 +57,8 @@ def valid_advertisement_headers(headers: Mapping[str, Any]) -> bool:
 
 def extract_valid_to(headers: Mapping[str, Any]) -> datetime:
     """Extract/create valid to."""
-    match = CACHE_CONTROL_RE.search(headers.get("cache-controle", ""))
+    cache_control = headers.get("cache-control", "")
+    match = CACHE_CONTROL_RE.search(cache_control)
     if match:
         max_age = int(match[1])
         uncache_after = timedelta(seconds=max_age)

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -9,10 +9,10 @@ from collections.abc import Mapping as abcMapping
 from collections.abc import MutableMapping as abcMutableMapping
 from datetime import datetime, timedelta, timezone
 from socket import AddressFamily  # pylint: disable=no-name-in-module
-from typing import Any, Callable, Dict, Generator, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, Optional, Tuple
 from urllib.parse import urljoin, urlsplit
 
-import defusedxml as DET
+import defusedxml.ElementTree as DET
 from voluptuous import Invalid
 
 EXTERNAL_IP = "1.1.1.1"
@@ -133,7 +133,7 @@ def parse_date_time(value: str) -> Any:
     utc = timezone(timedelta(hours=0))
     if value[-6] in ["+", "-"] and value[-3] == ":":
         value = value[:-3] + value[-2:]
-    matchers: Mapping[str, Callable] = {
+    matchers: Dict[str, Callable] = {
         # date
         r"\d{4}-\d{2}-\d{2}$": lambda s: datetime.strptime(value, "%Y-%m-%d").date(),
         r"\d{2}:\d{2}:\d{2}$": lambda s: datetime.strptime(value, "%H:%M:%S").time(),
@@ -224,17 +224,17 @@ async def async_get_local_ip(
 # Adapted from http://stackoverflow.com/a/10077069
 # to follow the XML to JSON spec
 # https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html
-def etree_to_dict(tree: DET.ElementTree) -> dict[str, Optional[dict[str, Any]]]:
+def etree_to_dict(tree: DET) -> Dict[str, Optional[Dict[str, Any]]]:
     """Convert an ETree object to a dict."""
     # strip namespace
     tag_name = tree.tag[tree.tag.find("}") + 1 :]
 
-    tree_dict: dict[str, Optional[dict[str, Any]]] = {
+    tree_dict: Dict[str, Optional[Dict[str, Any]]] = {
         tag_name: {} if tree.attrib else None
     }
     children = list(tree)
     if children:
-        child_dict: dict[str, list] = defaultdict(list)
+        child_dict: Dict[str, list] = defaultdict(list)
         for child in map(etree_to_dict, children):
             for k, val in child.items():
                 child_dict[k].append(val)

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -27,9 +27,11 @@ def _ci_key(key: str) -> str:
 class CaseInsensitiveDict(abcMutableMapping):
     """Case insensitive dict."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, data: Optional[abcMapping] = None, **kwargs: Any) -> None:
         """Initialize."""
         self._data: Dict[str, Any] = {}
+        for key, value in (data or {}).items():
+            self[key] = value
         for key, value in kwargs.items():
             self[key] = value
 
@@ -54,7 +56,7 @@ class CaseInsensitiveDict(abcMutableMapping):
 
     def __iter__(self) -> Generator[str, None, None]:
         """Get iterator."""
-        return (key for key, value in self._data.values())
+        return (key for key, _ in self._data.values())
 
     def __repr__(self) -> str:
         """Repr."""

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -6,7 +6,7 @@ import re
 import socket
 from collections import defaultdict
 from collections.abc import Mapping as abcMapping
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping as abcMutableMapping
 from datetime import datetime, timedelta, timezone
 from socket import AddressFamily  # pylint: disable=no-name-in-module
 from typing import Any, Callable, Dict, Generator, Mapping, Optional, Tuple
@@ -24,7 +24,7 @@ def _ci_key(key: str) -> str:
     return key.lower()
 
 
-class CaseInsensitiveDict(MutableMapping):
+class CaseInsensitiveDict(abcMutableMapping):
     """Case insensitive dict."""
 
     def __init__(self, **kwargs: Any) -> None:
@@ -52,7 +52,7 @@ class CaseInsensitiveDict(MutableMapping):
         """Get length."""
         return len(self._data)
 
-    def __iter__(self) -> Generator[Any, None, None]:
+    def __iter__(self) -> Generator[str, None, None]:
         """Get iterator."""
         return (key for key, value in self._data.values())
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,22 @@ python-tag=py3
 license_file = LICENSE.md
 
 [flake8]
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 max-line-length = 119
+max-complexity = 25
+# To work with Black
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+    W504
+noqa-require-code = True
 
 [mypy]
 check_untyped_defs = true

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ TEST_REQUIRES = [
 
 setup(
     name="async_upnp_client",
-    version="0.20.1.dev0",
+    version="0.21.0.dev0",
     description="Async UPnP Client",
     long_description=LONG_DESCRIPTION,
     url="https://github.com/StevenLooman/async_upnp_client",

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,38 @@
+"""Common test parts."""
+
+from datetime import datetime
+
+from async_upnp_client.utils import CaseInsensitiveDict
+
+ADVERTISEMENT_REQUEST_LINE = "NOTIFY * HTTP/1.1"
+ADVERTISEMENT_HEADERS_DEFAULT = CaseInsensitiveDict(
+    {
+        "CACHE-CONTROL": "max-age=1800",
+        "NTS": "ssdp:alive",
+        "NT": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
+        "BOOTID.UPNP.ORG": "1",
+        "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
+        "_timestamp": datetime(2021, 1, 1, 12, 00),
+        "_host": "192.168.1.1",
+        "_port": "1900",
+        "_udn": "uuid:...:",
+    }
+)
+SEACH_REQUEST_LINE = "HTTP/1.1 200 OK"
+SEARCH_HEADERS_DEFAULT = CaseInsensitiveDict(
+    {
+        "CACHE-CONTROL": "max-age=1800",
+        "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
+        "BOOTID.UPNP.ORG": "1",
+        "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
+        "DATE": "Fri, 1 Jan 2021 12:00:00 GMT",
+        "_timestamp": datetime(2021, 1, 1, 12, 00),
+        "_host": "192.168.1.1",
+        "_port": "1900",
+        "_udn": "uuid:...:",
+    }
+)

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -11,7 +11,6 @@ except ImportError:
 import pytest
 
 from async_upnp_client.advertisement import SsdpAdvertisementListener
-from async_upnp_client.const import SsdpSource
 from async_upnp_client.utils import CaseInsensitiveDict
 
 TEST_REQUEST_LINE = "NOTIFY * HTTP/1.1"
@@ -23,11 +22,10 @@ TEST_HEADERS_DEFAULT = {
     "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
     "BOOTID.UPNP.ORG": "1",
     "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
-    # "_timestamp": datetime.fromisoformat("2021-01-01 12:00"),  # Python 3.7+
-    "_timestamp": datetime.strptime("2021-01-01 12:00", "%Y-%m-%d %H:%M"),
+    "_timestamp": datetime(2021, 1, 1, 12, 00),
     "_host": "192.168.1.1",
     "_port": "1900",
-    "_source": SsdpSource.ADVERTISEMENT,
+    "_udn": "uuid:...:",
 }
 
 
@@ -41,7 +39,7 @@ async def test_receive_ssdp_alive() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
+    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:alive"
     await listener._async_on_data(TEST_REQUEST_LINE, headers)
 
@@ -60,7 +58,7 @@ async def test_receive_ssdp_byebye() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
+    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:byebye"
     await listener._async_on_data(TEST_REQUEST_LINE, headers)
 
@@ -79,10 +77,42 @@ async def test_receive_ssdp_update() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
+    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:update"
     await listener._async_on_data(TEST_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_not_called()
     on_update.assert_called_with(headers)
+
+
+@pytest.mark.asyncio
+async def test_receive_ssdp_search_response() -> None:
+    """Test handling a ssdp search response, which is ignored."""
+    # pylint: disable=protected-access
+    on_alive = AsyncMock()
+    on_byebye = AsyncMock()
+    on_update = AsyncMock()
+    listener = SsdpAdvertisementListener(
+        on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
+    )
+    headers = CaseInsensitiveDict(
+        {
+            "CACHE-CONTROL": "max-age=1800",
+            "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+            "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+            "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
+            "BOOTID.UPNP.ORG": "1",
+            "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
+            "DATE": "Fri, 1 Jan 2021 12:00:00 GMT",
+            "_timestamp": datetime(2021, 1, 1, 12, 00),
+            "_host": "192.168.1.1",
+            "_port": "1900",
+            "_udn": "uuid:...:",
+        }
+    )
+    await listener._async_on_data("HTTP/1.1 200 OK", headers)
+
+    on_alive.assert_not_called()
+    on_byebye.assert_not_called()
+    on_update.assert_not_called()

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -11,6 +11,7 @@ except ImportError:
 import pytest
 
 from async_upnp_client.advertisement import SsdpAdvertisementListener
+from async_upnp_client.const import SsdpSource
 from async_upnp_client.utils import CaseInsensitiveDict
 
 TEST_REQUEST_LINE = "NOTIFY * HTTP/1.1"
@@ -26,6 +27,7 @@ TEST_HEADERS_DEFAULT = {
     "_timestamp": datetime.strptime("2021-01-01 12:00", "%Y-%m-%d %H:%M"),
     "_host": "192.168.1.1",
     "_port": "1900",
+    "_source": SsdpSource.ADVERTISEMENT,
 }
 
 

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import pytest
 
-from async_upnp_client.advertisement import UpnpAdvertisementListener
+from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.utils import CaseInsensitiveDict
 
 TEST_REQUEST_LINE = "NOTIFY * HTTP/1.1"
@@ -36,12 +36,12 @@ async def test_receive_ssdp_alive() -> None:
     on_alive = AsyncMock()
     on_byebye = AsyncMock()
     on_update = AsyncMock()
-    listener = UpnpAdvertisementListener(
+    listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
     headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:alive"
-    await listener._on_data(TEST_REQUEST_LINE, headers)
+    await listener._async_on_data(TEST_REQUEST_LINE, headers)
 
     on_alive.assert_called_with(headers)
     on_byebye.assert_not_called()
@@ -55,12 +55,12 @@ async def test_receive_ssdp_byebye() -> None:
     on_alive = AsyncMock()
     on_byebye = AsyncMock()
     on_update = AsyncMock()
-    listener = UpnpAdvertisementListener(
+    listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
     headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:byebye"
-    await listener._on_data(TEST_REQUEST_LINE, headers)
+    await listener._async_on_data(TEST_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_called_with(headers)
@@ -74,12 +74,12 @@ async def test_receive_ssdp_update() -> None:
     on_alive = AsyncMock()
     on_byebye = AsyncMock()
     on_update = AsyncMock()
-    listener = UpnpAdvertisementListener(
+    listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
     headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:update"
-    await listener._on_data(TEST_REQUEST_LINE, headers)
+    await listener._async_on_data(TEST_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_not_called()

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -1,7 +1,5 @@
 """Unit tests for advertisement."""
 
-from datetime import datetime
-
 try:
     from unittest.mock import AsyncMock
 except ImportError:
@@ -13,20 +11,12 @@ import pytest
 from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.utils import CaseInsensitiveDict
 
-TEST_REQUEST_LINE = "NOTIFY * HTTP/1.1"
-TEST_HEADERS_DEFAULT = {
-    "CACHE-CONTROL": "max-age=1800",
-    "NTS": "ssdp:alive",
-    "NT": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-    "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-    "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
-    "BOOTID.UPNP.ORG": "1",
-    "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
-    "_timestamp": datetime(2021, 1, 1, 12, 00),
-    "_host": "192.168.1.1",
-    "_port": "1900",
-    "_udn": "uuid:...:",
-}
+from .common import (
+    ADVERTISEMENT_HEADERS_DEFAULT,
+    ADVERTISEMENT_REQUEST_LINE,
+    SEACH_REQUEST_LINE,
+    SEARCH_HEADERS_DEFAULT,
+)
 
 
 @pytest.mark.asyncio
@@ -39,9 +29,9 @@ async def test_receive_ssdp_alive() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
+    headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:alive"
-    await listener._async_on_data(TEST_REQUEST_LINE, headers)
+    await listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
 
     on_alive.assert_called_with(headers)
     on_byebye.assert_not_called()
@@ -58,9 +48,9 @@ async def test_receive_ssdp_byebye() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
+    headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:byebye"
-    await listener._async_on_data(TEST_REQUEST_LINE, headers)
+    await listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_called_with(headers)
@@ -77,9 +67,9 @@ async def test_receive_ssdp_update() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
+    headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = "ssdp:update"
-    await listener._async_on_data(TEST_REQUEST_LINE, headers)
+    await listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_not_called()
@@ -96,22 +86,8 @@ async def test_receive_ssdp_search_response() -> None:
     listener = SsdpAdvertisementListener(
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
-    headers = CaseInsensitiveDict(
-        {
-            "CACHE-CONTROL": "max-age=1800",
-            "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-            "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-            "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
-            "BOOTID.UPNP.ORG": "1",
-            "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
-            "DATE": "Fri, 1 Jan 2021 12:00:00 GMT",
-            "_timestamp": datetime(2021, 1, 1, 12, 00),
-            "_host": "192.168.1.1",
-            "_port": "1900",
-            "_udn": "uuid:...:",
-        }
-    )
-    await listener._async_on_data("HTTP/1.1 200 OK", headers)
+    headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
+    await listener._async_on_data(SEACH_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_not_called()

--- a/tests/test_description_cache.py
+++ b/tests/test_description_cache.py
@@ -1,0 +1,131 @@
+"""Unit tests for description_cache."""
+
+import asyncio
+from unittest.mock import patch
+
+import aiohttp
+import defusedxml.ElementTree as DET
+import pytest
+
+from async_upnp_client.description_cache import DescriptionCache
+
+from .upnp_test_requester import UpnpTestRequester
+
+
+@pytest.mark.asyncio
+async def test_fetch_parse_success() -> None:
+    """Test properly fetching and parsing a description."""
+    xml = """<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:TestDevice:1</deviceType>
+    <UDN>uuid:test_udn</UDN>
+  </device>
+</root>"""
+    requester = UpnpTestRequester(
+        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+    )
+    description_cache = DescriptionCache(requester)
+    descr_xml = await description_cache.async_get_description_xml(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_xml == xml
+
+    descr_dict = await description_cache.async_get_description_dict(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_dict == {
+        "deviceType": "urn:schemas-upnp-org:device:TestDevice:1",
+        "UDN": "uuid:test_udn",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_parse_success_invalid_chars() -> None:
+    """Test fail parsing a description with invalid characters."""
+    xml = """<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:TestDevice:1</deviceType>
+    <UDN>uuid:test_udn</UDN>
+    <serialNumber>\xff\xff\xff\xff</serialNumber>
+  </device>
+</root>"""
+    requester = UpnpTestRequester(
+        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+    )
+    description_cache = DescriptionCache(requester)
+    descr_xml = await description_cache.async_get_description_xml(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_xml == xml
+
+    descr_dict = await description_cache.async_get_description_dict(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_dict == {
+        "deviceType": "urn:schemas-upnp-org:device:TestDevice:1",
+        "UDN": "uuid:test_udn",
+        "serialNumber": "ÿÿÿÿ",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [asyncio.TimeoutError, aiohttp.ClientError])
+async def test_fetch_fail(exc: Exception) -> None:
+    """Test fail fetching a description."""
+    xml = ""
+    requester = UpnpTestRequester(
+        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+    )
+    requester.exceptions.append(exc)
+    description_cache = DescriptionCache(requester)
+    descr_xml = await description_cache.async_get_description_xml(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_xml is None
+
+    descr_dict = await description_cache.async_get_description_dict(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_dict is None
+
+
+@pytest.mark.asyncio
+async def test_parsing_fail_invalid_xml() -> None:
+    """Test fail parsing a description with invalid XML."""
+    xml = """<root xmlns="urn:schemas-upnp-org:device-1-0">INVALIDXML"""
+    requester = UpnpTestRequester(
+        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+    )
+    description_cache = DescriptionCache(requester)
+    descr_xml = await description_cache.async_get_description_xml(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_xml == xml
+
+    descr_dict = await description_cache.async_get_description_dict(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_dict is None
+
+
+@pytest.mark.asyncio
+async def test_parsing_fail_error() -> None:
+    """Test fail parsing a description with invalid XML."""
+    xml = ""
+    requester = UpnpTestRequester(
+        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+    )
+    description_cache = DescriptionCache(requester)
+    descr_xml = await description_cache.async_get_description_xml(
+        "http://192.168.1.1/desc.xml"
+    )
+    assert descr_xml == xml
+
+    with patch(
+        "async_upnp_client.description_cache.DET.fromstring",
+        side_effect=DET.ParseError,
+    ):
+        descr_dict = await description_cache.async_get_description_dict(
+            "http://192.168.1.1/desc.xml"
+        )
+        assert descr_dict is None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,12 +3,12 @@
 
 from typing import Any
 
-from async_upnp_client.search import SSDPListener
+from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.ssdp import SSDP_IP_V4
 
 
 def test_create_ssdp_listener_with_alternate_target() -> None:
-    """Create a SSDPListener on an alternate target."""
+    """Create a SsdpSearchListener on an alternate target."""
 
     async def _dummy_callback(*_: Any) -> None:
         # Nop.
@@ -16,7 +16,7 @@ def test_create_ssdp_listener_with_alternate_target() -> None:
 
     yeelight_target = (SSDP_IP_V4, 1982)
     yeelight_service_type = "wifi_bulb"
-    listener = SSDPListener(
+    listener = SsdpSearchListener(
         async_callback=_dummy_callback,
         async_connect_callback=_dummy_callback,
         service_type=yeelight_service_type,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,30 +1,66 @@
 """Unit tests for search."""
 # pylint: disable=protected-access
 
-from typing import Any
+from datetime import datetime
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # For python 3.6/3.7
+    from mock import AsyncMock  # type: ignore
+
+import pytest
+
+from async_upnp_client.const import SsdpSource
 from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.ssdp import SSDP_IP_V4
+from async_upnp_client.utils import CaseInsensitiveDict
+
+TEST_REQUEST_LINE = "HTTP/1.1 200 OK"
+TEST_HEADERS_DEFAULT = {
+    "CACHE-CONTROL": "max-age=1800",
+    "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+    "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
+    "BOOTID.UPNP.ORG": "1",
+    "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
+    "DATE": "Fri, 1 Jan 2021 12:00:00 GMT",
+    # "_timestamp": datetime.fromisoformat("2021-01-01 12:00"),  # Python 3.7+
+    "_timestamp": datetime.strptime("2021-01-01 12:00", "%Y-%m-%d %H:%M"),
+    "_host": "192.168.1.1",
+    "_port": "1900",
+    "_udn": "uuid:...",
+    "_source": SsdpSource.SEARCH,
+}
+
+
+@pytest.mark.asyncio
+async def test_receive_serach_response() -> None:
+    """Test handling a ssdp:alive advertisement."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpSearchListener(async_callback=callback)
+    headers = CaseInsensitiveDict(**TEST_HEADERS_DEFAULT)
+    await listener._async_on_data(TEST_REQUEST_LINE, headers)
+
+    callback.assert_called_with(headers)
 
 
 def test_create_ssdp_listener_with_alternate_target() -> None:
     """Create a SsdpSearchListener on an alternate target."""
-
-    async def _dummy_callback(*_: Any) -> None:
-        # Nop.
-        pass
+    callback = AsyncMock()
+    connect_callback = AsyncMock()
 
     yeelight_target = (SSDP_IP_V4, 1982)
     yeelight_service_type = "wifi_bulb"
     listener = SsdpSearchListener(
-        async_callback=_dummy_callback,
-        async_connect_callback=_dummy_callback,
+        async_callback=callback,
+        async_connect_callback=connect_callback,
         service_type=yeelight_service_type,
         target=yeelight_target,
     )
 
     assert listener._target == yeelight_target
     assert listener.service_type == yeelight_service_type
-    # pylint: disable=comparison-with-callable
-    assert listener.async_callback == _dummy_callback
-    assert listener.async_connect_callback == _dummy_callback
+    assert listener.async_callback == callback
+    assert listener.async_connect_callback == connect_callback

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,8 +1,6 @@
 """Unit tests for search."""
 # pylint: disable=protected-access
 
-from datetime import datetime
-
 try:
     from unittest.mock import AsyncMock
 except ImportError:
@@ -15,20 +13,12 @@ from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.ssdp import SSDP_IP_V4
 from async_upnp_client.utils import CaseInsensitiveDict
 
-TEST_REQUEST_LINE = "HTTP/1.1 200 OK"
-TEST_HEADERS_DEFAULT = {
-    "CACHE-CONTROL": "max-age=1800",
-    "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-    "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-    "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
-    "BOOTID.UPNP.ORG": "1",
-    "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
-    "DATE": "Fri, 1 Jan 2021 12:00:00 GMT",
-    "_timestamp": datetime(2021, 1, 1, 12, 00),
-    "_host": "192.168.1.1",
-    "_port": "1900",
-    "_udn": "uuid:...:",
-}
+from .common import (
+    ADVERTISEMENT_HEADERS_DEFAULT,
+    ADVERTISEMENT_REQUEST_LINE,
+    SEACH_REQUEST_LINE,
+    SEARCH_HEADERS_DEFAULT,
+)
 
 
 @pytest.mark.asyncio
@@ -37,8 +27,8 @@ async def test_receive_search_response() -> None:
     # pylint: disable=protected-access
     callback = AsyncMock()
     listener = SsdpSearchListener(async_callback=callback)
-    headers = CaseInsensitiveDict(TEST_HEADERS_DEFAULT)
-    await listener._async_on_data(TEST_REQUEST_LINE, headers)
+    headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
+    await listener._async_on_data(SEACH_REQUEST_LINE, headers)
 
     callback.assert_called_with(headers)
 
@@ -68,21 +58,7 @@ async def test_receive_ssdp_alive_advertisement() -> None:
     """Test handling a ssdp alive advertisement, which is ignored."""
     callback = AsyncMock()
     listener = SsdpSearchListener(async_callback=callback)
-    headers = CaseInsensitiveDict(
-        {
-            "CACHE-CONTROL": "max-age=1800",
-            "NTS": "ssdp:alive",
-            "NT": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-            "USN": "uuid:...::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
-            "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
-            "BOOTID.UPNP.ORG": "1",
-            "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
-            "_timestamp": datetime(2021, 1, 1, 12, 00),
-            "_host": "192.168.1.1",
-            "_port": "1900",
-            "_udn": "uuid:...:",
-        }
-    )
-    await listener._async_on_data("NOTIFY * HTTP/1.1", headers)
+    headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
+    await listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
 
     callback.assert_not_called()

--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -1,4 +1,4 @@
-"""Unit tests for discovery."""
+"""Unit tests for ssdp."""
 from ipaddress import IPv4Address
 from unittest.mock import ANY
 

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -1,0 +1,260 @@
+"""Unit tests for ssdp listener."""
+
+from datetime import datetime, timedelta
+from ipaddress import ip_address
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from async_upnp_client.advertisement import SsdpAdvertisementListener
+from async_upnp_client.const import NotificationSubType
+from async_upnp_client.search import SsdpSearchListener
+from async_upnp_client.ssdp_listener import SsdpListener
+from async_upnp_client.utils import CaseInsensitiveDict
+
+TEST_NOTIFY_REQUEST_LINE = "NOTIFY * HTTP/1.1"
+TEST_UDN = "uuid:test_udn"
+TEST_SERVICE = "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1"
+TEST_NOTIFY_HEADERS = {
+    "CACHE-CONTROL": "max-age=1800",
+    "NTS": "ssdp:alive",
+    "NT": TEST_SERVICE,
+    "USN": TEST_UDN + "::" + TEST_SERVICE,
+    "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
+    "BOOTID.UPNP.ORG": "1",
+    "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
+    "_timestamp": datetime.now(),
+    "_host": "192.168.1.1",
+    "_port": "1900",
+    "_udn": TEST_UDN,
+    "_source": "advertisement",
+}
+TEST_SEARCH_REQUEST_LINE = "HTTP/1.1 200 OK"
+TEST_SEARCH_HEADERS = {
+    "CACHE-CONTROL": "max-age=1800",
+    "ST": TEST_SERVICE,
+    "USN": TEST_UDN + "::" + TEST_SERVICE,
+    "LOCATION": "http://192.168.1.1:80/RootDevice.xml",
+    "BOOTID.UPNP.ORG": "1",
+    "SERVER": "Linux/2.0 UPnP/1.0 async_upnp_client/0.1",
+    "DATE": "Fri, 1 Jan 2021 12:00:00 GMT",
+    "_timestamp": datetime.now(),
+    "_host": "192.168.1.1",
+    "_port": "1900",
+    "_udn": TEST_UDN,
+    "_source": "search",
+}
+
+
+@pytest.fixture
+async def mock_start_listeners() -> AsyncGenerator:
+    """Create listeners but don't call async_start()."""
+    # pylint: disable=protected-access
+
+    async def async_start(self: SsdpListener) -> None:
+        target_ip = ip_address(self.target[0])
+        self._advertisement_listener = SsdpAdvertisementListener(
+            on_alive=self._on_alive,
+            on_update=self._on_update,
+            on_byebye=self._on_byebye,
+            source_ip=self.source_ip,
+            target_ip=target_ip,
+            loop=self.loop,
+        )
+
+        self._search_listener = SsdpSearchListener(
+            self._on_search,
+            loop=self.loop,
+            source_ip=self.source_ip,
+            target=self.target,
+            timeout=self.search_timeout,
+        )
+
+    with patch.object(SsdpListener, "async_start", new=async_start) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_start_listeners")
+async def test_see_advertisement_alive() -> None:
+    """Test seeing a device through an ssdp:alive-advertisement."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpListener(callback=callback)
+    await listener.async_start()
+    advertisement_listener = listener._advertisement_listener
+    assert advertisement_listener is not None
+
+    # See device for the first time through alive-advertisement.
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_ALIVE
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    await listener.async_stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_start_listeners")
+async def test_see_advertisement_byebye() -> None:
+    """Test seeing a device through an ssdp:byebye-advertisement."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpListener(callback=callback)
+    await listener.async_start()
+    advertisement_listener = listener._advertisement_listener
+    assert advertisement_listener is not None
+
+    # See device for the first time through byebye-advertisement, not triggering callback.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_BYEBYE
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_not_awaited()
+    assert TEST_UDN not in listener.devices
+
+    # See device for the first time through alive-advertisement, triggering callback.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_ALIVE
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    # See device for the second time through byebye-advertisement, triggering callback.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_BYEBYE
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN not in listener.devices
+
+    await listener.async_stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_start_listeners")
+async def test_see_advertisement_update() -> None:
+    """Test seeing a device through an ssdp:update-advertisement."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpListener(callback=callback)
+    await listener.async_start()
+    advertisement_listener = listener._advertisement_listener
+    assert advertisement_listener is not None
+
+    # See device for the first time through alive-advertisement, triggering callback.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_ALIVE
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    # See device for the second time through update-advertisement, triggering callback.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_UPDATE
+    headers["BOOTID.UPNP.ORG"] = "2"
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    await listener.async_stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_start_listeners")
+async def test_see_search() -> None:
+    """Test seeing a device through an search."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpListener(callback=callback)
+    await listener.async_start()
+    search_listener = listener._search_listener
+    assert search_listener is not None
+
+    # See device for the first time through search.
+    headers = CaseInsensitiveDict(**TEST_SEARCH_HEADERS)
+    await search_listener._async_on_data(
+        request_line=TEST_SEARCH_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    await listener.async_stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_start_listeners")
+async def test_see_search_then_alive() -> None:
+    """Test seeing a device through a search."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpListener(callback=callback)
+    await listener.async_start()
+    advertisement_listener = listener._advertisement_listener
+    assert advertisement_listener is not None
+    search_listener = listener._search_listener
+    assert search_listener is not None
+
+    # See device for the first time through search.
+    headers = CaseInsensitiveDict(**TEST_SEARCH_HEADERS)
+    await search_listener._async_on_data(
+        request_line=TEST_SEARCH_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    # See device for the second time through alive-advertisement, not triggering callback.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
+    headers["NTS"] = NotificationSubType.SSDP_ALIVE
+    await advertisement_listener._async_on_data(
+        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
+    )
+    callback.assert_not_awaited()
+    assert TEST_UDN in listener.devices
+
+    await listener.async_stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_start_listeners")
+async def test_purge_devices() -> None:
+    """Test if a device is purged when it times out given the value of the CACHE-CONTROL header."""
+    # pylint: disable=protected-access
+    callback = AsyncMock()
+    listener = SsdpListener(callback=callback)
+    await listener.async_start()
+    search_listener = listener._search_listener
+    assert search_listener is not None
+
+    # See device for the first time through alive-advertisement.
+    headers = CaseInsensitiveDict(**TEST_SEARCH_HEADERS)
+    await search_listener._async_on_data(
+        request_line=TEST_SEARCH_REQUEST_LINE, headers=headers
+    )
+    callback.assert_awaited()
+    assert TEST_UDN in listener.devices
+
+    # "Wait" a bit... and purge devices.
+    override_now = datetime.now() + timedelta(hours=1)
+    listener._device_tracker.purge_devices(override_now)
+    assert TEST_UDN not in listener.devices
+
+    await listener.async_stop()

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -3,7 +3,13 @@
 from datetime import datetime, timedelta
 from ipaddress import ip_address
 from typing import AsyncGenerator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
+
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # For python 3.6/3.7
+    from mock import AsyncMock  # type: ignore
 
 import pytest
 

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -95,9 +95,7 @@ async def test_see_advertisement_alive() -> None:
     # See device for the first time through alive-advertisement.
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 
@@ -119,9 +117,7 @@ async def test_see_advertisement_byebye() -> None:
     callback.reset_mock()
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_BYEBYE
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_not_awaited()
     assert TEST_UDN not in listener.devices
 
@@ -129,9 +125,7 @@ async def test_see_advertisement_byebye() -> None:
     callback.reset_mock()
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 
@@ -139,9 +133,7 @@ async def test_see_advertisement_byebye() -> None:
     callback.reset_mock()
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_BYEBYE
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN not in listener.devices
 
@@ -163,9 +155,7 @@ async def test_see_advertisement_update() -> None:
     callback.reset_mock()
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 
@@ -174,9 +164,7 @@ async def test_see_advertisement_update() -> None:
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_UPDATE
     headers["BOOTID.UPNP.ORG"] = "2"
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 
@@ -196,9 +184,7 @@ async def test_see_search() -> None:
 
     # See device for the first time through search.
     headers = CaseInsensitiveDict(**TEST_SEARCH_HEADERS)
-    await search_listener._async_on_data(
-        request_line=TEST_SEARCH_REQUEST_LINE, headers=headers
-    )
+    await search_listener._async_on_data(TEST_SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 
@@ -220,9 +206,7 @@ async def test_see_search_then_alive() -> None:
 
     # See device for the first time through search.
     headers = CaseInsensitiveDict(**TEST_SEARCH_HEADERS)
-    await search_listener._async_on_data(
-        request_line=TEST_SEARCH_REQUEST_LINE, headers=headers
-    )
+    await search_listener._async_on_data(TEST_SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 
@@ -230,9 +214,7 @@ async def test_see_search_then_alive() -> None:
     callback.reset_mock()
     headers = CaseInsensitiveDict(**TEST_NOTIFY_HEADERS)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
-    await advertisement_listener._async_on_data(
-        request_line=TEST_NOTIFY_REQUEST_LINE, headers=headers
-    )
+    await advertisement_listener._async_on_data(TEST_NOTIFY_REQUEST_LINE, headers)
     callback.assert_not_awaited()
     assert TEST_UDN in listener.devices
 
@@ -252,9 +234,7 @@ async def test_purge_devices() -> None:
 
     # See device for the first time through alive-advertisement.
     headers = CaseInsensitiveDict(**TEST_SEARCH_HEADERS)
-    await search_listener._async_on_data(
-        request_line=TEST_SEARCH_REQUEST_LINE, headers=headers
-    )
+    await search_listener._async_on_data(TEST_SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert TEST_UDN in listener.devices
 

--- a/tests/test_upnp_client.py
+++ b/tests/test_upnp_client.py
@@ -5,7 +5,7 @@ import socket
 from datetime import datetime, timedelta, timezone
 from typing import MutableMapping, Sequence
 
-import defusedxml.ElementTree as ET
+import defusedxml.ElementTree as DET
 import pytest
 
 from async_upnp_client import (
@@ -303,7 +303,7 @@ class TestUpnpAction:
             InstanceID=0, Channel="Master", DesiredVolume=10
         )
 
-        root = ET.fromstring(body)
+        root = DET.fromstring(body)
         namespace = {"rc_service": service_type}
         assert root.find(".//rc_service:SetVolume", namespace) is not None
         assert root.find(".//DesiredVolume", namespace) is not None
@@ -325,7 +325,7 @@ class TestUpnpAction:
             CurrentURIMetaData=metadata,
         )
 
-        root = ET.fromstring(body)
+        root = DET.fromstring(body)
         namespace = {"avt_service": service_type}
         assert root.find(".//avt_service:SetAVTransportURI", namespace) is not None
         assert root.find(".//CurrentURIMetaData", namespace) is not None

--- a/tests/upnp_test_requester.py
+++ b/tests/upnp_test_requester.py
@@ -20,6 +20,8 @@ def read_file(filename: str) -> str:
 class UpnpTestRequester(UpnpRequester):
     """Test requester."""
 
+    # pylint: disable=too-few-public-methods
+
     def __init__(
         self,
         response_map: Mapping[Tuple[str, str], Tuple[int, Mapping[str, str], str]],

--- a/tests/upnp_test_requester.py
+++ b/tests/upnp_test_requester.py
@@ -33,7 +33,7 @@ class UpnpTestRequester(UpnpRequester):
         ] = deepcopy(cast(MutableMapping, response_map))
         self.exceptions: Deque[Optional[Exception]] = deque()
 
-    async def async_do_http_request(
+    async def async_http_request(
         self,
         method: str,
         url: str,


### PR DESCRIPTION
Unified `SsdpListener` to do searches and listen for advertisements. Upon change, perform a callback to inform the client-program it might want to take action.

This (also) moves the device-tracking functionality from the `ssdp` component in home assistant to this library.