### PR TITLE
Fix NoneType exception in media_image_url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 0.20.1 (unreleased)
 
 - More pylint/mypy
+- Fixed NoneType exception in DmrDevice.media_image_url @mkliche
 
 
 0.20.0 (2021-08-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 0.20.1 (unreleased)
 
 - More pylint/mypy
-- Fixed NoneType exception in DmrDevice.media_image_url @mkliche
+- Fixed NoneType exception in DmrDevice.media_image_url (@mkliche)
 
 
 0.20.0 (2021-08-17)

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -865,7 +865,7 @@ class DmrDevice(UpnpProfileDevice):
                 return absolute_url(device_url, item.album_art_uri)
 
             for res in item.resources:
-                protocol_info = res.protocol_info
+                protocol_info = res.protocol_info or ''
                 if protocol_info.startswith("http-get:*:image/"):
                     return absolute_url(device_url, res.url)
 


### PR DESCRIPTION
Fixes this exception occuring in Home Assistant:

```
Logger: homeassistant.components.media_player
Source: components/dlna_dmr/media_player.py:360
Integration: Mediaplayer (documentation, issues)
First occurred: 17:37:11 (2 occurrences)
Last logged: 17:37:11

Error adding entities for domain media_player with platform dlna_dmr
Error while setting up dlna_dmr platform for media_player
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 587, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 711, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 464, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 522, in _async_write_ha_state
    entity_picture = self.entity_picture
  File "/usr/src/homeassistant/homeassistant/components/media_player/__init__.py", line 872, in entity_picture
    return self.media_image_local
  File "/usr/src/homeassistant/homeassistant/components/media_player/__init__.py", line 877, in media_image_local
    image_hash = self.media_image_hash
  File "/usr/src/homeassistant/homeassistant/components/media_player/__init__.py", line 485, in media_image_hash
    url = self.media_image_url
  File "/usr/src/homeassistant/homeassistant/components/dlna_dmr/media_player.py", line 360, in media_image_url
    return self._device.media_image_url
  File "/usr/local/lib/python3.9/site-packages/async_upnp_client/profiles/dlna.py", line 873, in media_image_url
    if protocol_info.startswith("http-get:*:image/"):
AttributeError: 'NoneType' object has no attribute 'startswith'

```