### PR TITLE
Reduce __getitem__ calls in CaseInsensitiveDict.replace

### DIFF
--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -37,8 +37,11 @@ class CaseInsensitiveDict(abcMutableMapping):
 
     def replace(self, new_data: abcMapping) -> None:
         """Replace the underlying dict."""
-        self._data = {**new_data}
-        self._case_map = {k.lower(): k for k in new_data}
+        if isinstance(new_data, CaseInsensitiveDict):
+            self._data = new_data.as_dict().copy()
+        else:
+            self._data = new_data.copy()
+        self._case_map = {k.lower(): k for k in self._data}
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set item."""

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -40,7 +40,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         if isinstance(new_data, CaseInsensitiveDict):
             self._data = new_data.as_dict().copy()
         else:
-            self._data = new_data.copy()
+            self._data = {**new_data}
         self._case_map = {k.lower(): k for k in self._data}
 
     def __setitem__(self, key: str, value: Any) -> None:


### PR DESCRIPTION
This is small optimization, but considering how often it happens it seemed worth doing.

Before:
<img width="719" alt="Screen Shot 2021-09-13 at 10 48 20 AM" src="https://user-images.githubusercontent.com/663432/133154314-397a84d7-61ab-4829-b8a3-42c501679677.png">

After:
<img width="965" alt="Screen Shot 2021-09-13 at 10 48 25 AM" src="https://user-images.githubusercontent.com/663432/133154354-3e331a38-29e9-4acb-a598-ccb04eb3a694.png">
