### PR TITLE
Update tracked device headers when unsee_advertisement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 0.21.3 (unreleased)
 
+ - Fix `ssdp_listener.SsdpDeviceTracker` to update device's headers upon ssdp:byebye advertisement (@chishm)
 
 0.21.2 (2021-09-12)
 

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -272,8 +272,14 @@ class SsdpDeviceTracker:
         ssdp_device = self.devices[udn]
         del self.devices[udn]
 
-        propagate = True  # Always true, if this is the 2nd unsee then device is already deleted.
+        # Update device before propagating it
         notification_type: NotificationType = headers["NT"]
+        current_headers = ssdp_device.advertisement_headers.setdefault(
+            notification_type, CaseInsensitiveDict()
+        )
+        current_headers.replace(headers)
+
+        propagate = True  # Always true, if this is the 2nd unsee then device is already deleted.
         return propagate, ssdp_device, notification_type
 
     def get_device(self, headers: SsdpHeaders) -> Optional[SsdpDevice]:

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -108,7 +108,10 @@ async def test_see_advertisement_byebye() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once()
+    assert callback.await_args is not None
+    device, dst, _ = callback.await_args.args
+    assert device.combined_headers(dst)["NTS"] == "ssdp:alive"
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through byebye-advertisement, triggering callback.
@@ -116,7 +119,10 @@ async def test_see_advertisement_byebye() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_BYEBYE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once()
+    assert callback.await_args is not None
+    device, dst, _ = callback.await_args.args
+    assert device.combined_headers(dst)["NTS"] == "ssdp:byebye"
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] not in listener.devices
 
     await listener.async_stop()


### PR DESCRIPTION
When propagating a device going byebye, make sure to update the device's headers too. This allows the callback registered with `SsdpListener`  to use the "NTS" header to filter for "ssdp:byebye".