### PR TITLE
Keep track of next valid to

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -296,11 +296,13 @@ class SsdpDeviceTracker:
         now = override_now or datetime.now()
         if self.next_valid_to and self.next_valid_to > now:
             return
-        to_remove = [
-            usn
-            for usn, device in self.devices.items()
-            if device.valid_to and now > device.valid_to
-        ]
+        self.next_valid_to = None
+        to_remove = []
+        for usn, device in self.devices.items():
+            if now > device.valid_to:
+                to_remove.append(usn)
+            elif not self.next_valid_to or device.valid_to < self.next_valid_to:
+                self.next_valid_to = device.valid_to
         for usn in to_remove:
             _LOGGER.debug("Purging device, USN: %s", usn)
             del self.devices[usn]

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -220,7 +220,24 @@ async def test_purge_devices() -> None:
     callback.assert_awaited()
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
+    # See device for the second time through alive-advertisement.
+    headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
+    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    callback.assert_awaited()
+    assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
+
     # "Wait" a bit... and purge devices.
+    override_now = headers["_timestamp"] + timedelta(hours=1)
+    listener._device_tracker.purge_devices(override_now)
+    assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] not in listener.devices
+
+    # See device for the first time through alive-advertisement.
+    headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
+    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    callback.assert_awaited()
+    assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
+
+    # "Wait" a bit... and purge devices again.
     override_now = headers["_timestamp"] + timedelta(hours=1)
     listener._device_tracker.purge_devices(override_now)
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] not in listener.devices


### PR DESCRIPTION
Avoid iterating devices to purge when we know we have not reached the next time at least one device in the list will be ready to be removed