### PR TITLE
Always propagate search responses

### DIFF
--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -197,6 +197,10 @@ class SsdpSource(str, Enum):
     ADVERTISEMENT = "advertisement"
     SEARCH = "search"
 
+    # More detailed
+    SEARCH_ALIVE = "search_alive"
+    SEARCH_CHANGED = "search_changed"
+
     # More detailed.
     ADVERTISEMENT_ALIVE = "advertisement_alive"
     ADVERTISEMENT_BYEBYE = "advertisement_byebye"

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -146,7 +146,7 @@ class SsdpDeviceTracker:
 
     def see_search(
         self, headers: SsdpHeaders
-    ) -> Tuple[bool, Optional[SsdpDevice], Optional[DeviceOrServiceType]]:
+    ) -> Tuple[SsdpSource, Optional[SsdpDevice], Optional[DeviceOrServiceType]]:
         """See a device through a search."""
         if not valid_search_headers(headers):
             return False, None, None

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -166,22 +166,13 @@ class SsdpDeviceTracker:
         if is_new_service:
             _LOGGER.debug("See new service: %s, type: %s", ssdp_device, search_target)
 
-        propagate = (
-            is_new_device
-            or is_new_service
-            or headers_differ_from_existing_search(ssdp_device, search_target, headers)
-            or headers_differ_from_existing_advertisement(
-                ssdp_device, search_target, headers
-            )
-        )
-
         # Update stored headers.
         current_headers = ssdp_device.search_headers.setdefault(
             search_target, CaseInsensitiveDict()
         )
         current_headers.replace(headers)
 
-        return propagate, ssdp_device, search_target
+        return ssdp_device, search_target
 
     def see_advertisement(
         self, headers: SsdpHeaders
@@ -382,12 +373,11 @@ class SsdpListener:
     async def _on_search(self, headers: SsdpHeaders) -> None:
         """Search callback."""
         (
-            propagate,
             ssdp_device,
             device_or_service_type,
         ) = self._device_tracker.see_search(headers)
 
-        if propagate and ssdp_device and device_or_service_type:
+        if ssdp_device and device_or_service_type:
             await self.async_callback(
                 ssdp_device, device_or_service_type, SsdpSource.SEARCH
             )

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -392,6 +392,7 @@ class SsdpListener:
         ) = self._device_tracker.see_search(headers)
 
         if propagate and ssdp_device and device_or_service_type:
+            assert ssdp_source is not None
             await self.async_callback(ssdp_device, device_or_service_type, ssdp_source)
 
     async def _on_alive(self, headers: SsdpHeaders) -> None:

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -151,9 +151,6 @@ class SsdpDeviceTracker:
         if not valid_search_headers(headers):
             return False, None, None
 
-        udn = headers["_udn"]
-        is_new_device = udn not in self.devices
-
         ssdp_device = self._see_device(headers)
         if not ssdp_device:
             return False, None, None


### PR DESCRIPTION
home-assistant/core#55540 limited callbacks to only happen when something had changed in the search.  This is great for performance, but unfortunately, Sonos needs the callback regardless to tell it the device is still alive.

- Add more detail to the change type

`SEARCH_ALIVE`   - Search response, device is alive 
`SEARCH_CHANGED` - Search response, device is new or an attribute changed (implies the device is alive since it responded)

- Sonos relies on receiving these to reset the seen
  timer. When it stopped getting them it would mark
  the device unavailable.