### PR TITLE
Retry on ServerDisconnectedError

### DIFF
--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -133,13 +133,12 @@ class AiohttpSessionRequester(UpnpRequester):
         The HTTP/1.1 spec allows the server to disconnect at any time.
         We want to retry the request in this event.
         """
-        max_attempts = 3
-        for attempt in range(max_attempts):
+        for _ in range(2):
             try:
                 return await self._async_http_request(method, url, headers, body)
-            except aiohttp.ServerDisconnectedError as err:
-                if attempt == max_attempts - 1:
-                    raise UpnpConnectionError(str(err)) from err
+            except aiohttp.ServerDisconnectedError:
+                pass
+        return await self._async_http_request(method, url, headers, body)        
 
     async def _async_http_request(
         self,

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -135,9 +135,6 @@ class AiohttpSessionRequester(UpnpRequester):
         """
         max_attempts = 3
         for attempt in range(max_attempts):
-            _LOGGER.warning(
-                "HTTP R %s: %s %s %s %s", attempt, method, url, headers, body
-            )
             try:
                 return await self._async_http_request(method, url, headers, body)
             except aiohttp.ServerDisconnectedError as err:

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -138,7 +138,7 @@ class AiohttpSessionRequester(UpnpRequester):
                 return await self._async_http_request(method, url, headers, body)
             except aiohttp.ServerDisconnectedError:
                 pass
-        return await self._async_http_request(method, url, headers, body)        
+        return await self._async_http_request(method, url, headers, body)
 
     async def _async_http_request(
         self,

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -186,7 +186,7 @@ class AiohttpSessionRequester(UpnpRequester):
                     resp_body_text = await response.text()
         except asyncio.TimeoutError as err:
             raise UpnpConnectionTimeoutError(str(err)) from err
-        except aiohttp.ServerDisconnectedError as err:
+        except aiohttp.ServerDisconnectedError:
             raise
         except aiohttp.ClientConnectionError as err:
             raise UpnpConnectionError(str(err)) from err


### PR DESCRIPTION
- The HTTP/1.1 spec allows a disconnect on a keep alive connection at any
  time and its up to the client to decide how to handle it. In this case
  we want to retry as we expect transient failures.

Fixes https://github.com/home-assistant/core/pull/55267#issuecomment-928075745