### PR TITLE
Add media metadata properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ share/*
 
 # Other
 prof/
+/.mypy_cache/


### PR DESCRIPTION
Add more property methods to `DmrDevice` to get metadata of currently playing media. The metadata is decoded once and cached each time the `CurrentTrackMetaData` state variable is updated.