### PR TITLE
Ignore SSDP searches/advertisements where the USN is malformed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 0.22.6 (unreleased)
 
 - Bump python-didl-lite to 1.3.0
+- More robustness in `ssdp_listener.SsdpListener` by requiring a parsed UDN (from USN) and location
 
 
 0.22.5 (2021-10-03)

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -112,6 +112,11 @@ def udn_from_headers(headers: SsdpHeaders) -> Optional[UniqueDeviceName]:
         parts = str(headers["usn"]).split("::")
         return parts[0]
 
+    # In case an invalid USN was received, i.e., UDN couldn't be extracted, use USN as UDN.
+    if "usn" in headers:
+        usn = headers["usn"]  # type: str
+        return usn
+
     return None
 
 

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -112,11 +112,6 @@ def udn_from_headers(headers: SsdpHeaders) -> Optional[UniqueDeviceName]:
         parts = str(headers["usn"]).split("::")
         return parts[0]
 
-    # In case an invalid USN was received, i.e., UDN couldn't be extracted, use USN as UDN.
-    if "usn" in headers:
-        usn = headers["usn"]  # type: str
-        return usn
-
     return None
 
 

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -34,12 +34,12 @@ IGNORED_HEADERS = {
 
 def valid_search_headers(headers: SsdpHeaders) -> bool:
     """Validate if this search is usable."""
-    return "usn" in headers and "st" in headers
+    return "_udn" in headers and "st" in headers
 
 
 def valid_advertisement_headers(headers: SsdpHeaders) -> bool:
     """Validate if this advertisement is usable."""
-    return "usn" in headers and "nt" in headers and "nts" in headers
+    return "_udn" in headers and "nt" in headers and "nts" in headers
 
 
 def extract_valid_to(headers: SsdpHeaders) -> datetime:
@@ -151,6 +151,7 @@ class SsdpDeviceTracker:
     ]:
         """See a device through a search."""
         if not valid_search_headers(headers):
+            _LOGGER.debug("Received invalid search headers: %s", headers)
             return False, None, None, None
 
         udn = headers["_udn"]
@@ -191,6 +192,7 @@ class SsdpDeviceTracker:
     ) -> Tuple[bool, Optional[SsdpDevice], Optional[DeviceOrServiceType]]:
         """See a device through an advertisement."""
         if not valid_advertisement_headers(headers):
+            _LOGGER.debug("Received invalid advertisement headers: %s", headers)
             return False, None, None
 
         udn = headers["_udn"]

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -34,12 +34,23 @@ IGNORED_HEADERS = {
 
 def valid_search_headers(headers: SsdpHeaders) -> bool:
     """Validate if this search is usable."""
-    return "_udn" in headers and "st" in headers
+    return (
+        "_udn" in headers
+        and "st" in headers
+        and "location" in headers
+        and headers.get("location", "").startswith("http")
+    )
 
 
 def valid_advertisement_headers(headers: SsdpHeaders) -> bool:
     """Validate if this advertisement is usable."""
-    return "_udn" in headers and "nt" in headers and "nts" in headers
+    return (
+        "_udn" in headers
+        and "nt" in headers
+        and "nts" in headers
+        and "location" in headers
+        and headers.get("location", "").startswith("http")
+    )
 
 
 def extract_valid_to(headers: SsdpHeaders) -> datetime:

--- a/tests/common.py
+++ b/tests/common.py
@@ -20,7 +20,7 @@ ADVERTISEMENT_HEADERS_DEFAULT = CaseInsensitiveDict(
         "_udn": "uuid:...",
     }
 )
-SEACH_REQUEST_LINE = "HTTP/1.1 200 OK"
+SEARCH_REQUEST_LINE = "HTTP/1.1 200 OK"
 SEARCH_HEADERS_DEFAULT = CaseInsensitiveDict(
     {
         "CACHE-CONTROL": "max-age=1800",

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -14,8 +14,8 @@ from async_upnp_client.utils import CaseInsensitiveDict
 from .common import (
     ADVERTISEMENT_HEADERS_DEFAULT,
     ADVERTISEMENT_REQUEST_LINE,
-    SEACH_REQUEST_LINE,
     SEARCH_HEADERS_DEFAULT,
+    SEARCH_REQUEST_LINE,
 )
 
 
@@ -87,7 +87,7 @@ async def test_receive_ssdp_search_response() -> None:
         on_alive=on_alive, on_byebye=on_byebye, on_update=on_update
     )
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await listener._async_on_data(SEARCH_REQUEST_LINE, headers)
 
     on_alive.assert_not_called()
     on_byebye.assert_not_called()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,8 +16,8 @@ from async_upnp_client.utils import CaseInsensitiveDict
 from .common import (
     ADVERTISEMENT_HEADERS_DEFAULT,
     ADVERTISEMENT_REQUEST_LINE,
-    SEACH_REQUEST_LINE,
     SEARCH_HEADERS_DEFAULT,
+    SEARCH_REQUEST_LINE,
 )
 
 
@@ -28,7 +28,7 @@ async def test_receive_search_response() -> None:
     callback = AsyncMock()
     listener = SsdpSearchListener(async_callback=callback)
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await listener._async_on_data(SEARCH_REQUEST_LINE, headers)
 
     callback.assert_called_with(headers)
 

--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -183,7 +183,7 @@ def test_get_ssdp_socket() -> None:
 
 
 def test_microsoft_butchers_ssdp() -> None:
-    """Test parsing a `urn:Microsoft Windows Peer Name Resolution Protocol: V4:IPV6:LinkLocal` packet."""
+    """Test parsing a `Microsoft Windows Peer Name Resolution Protocol` packet."""
     msg = (
         b"HTTP/1.1 200 OK\r\n"
         b"ST:urn:Microsoft Windows Peer Name Resolution Protocol: V4:IPV6:LinkLocal\r\n"

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -22,8 +22,8 @@ from async_upnp_client.utils import CaseInsensitiveDict
 from .common import (
     ADVERTISEMENT_HEADERS_DEFAULT,
     ADVERTISEMENT_REQUEST_LINE,
-    SEACH_REQUEST_LINE,
     SEARCH_HEADERS_DEFAULT,
+    SEARCH_REQUEST_LINE,
 )
 
 
@@ -172,7 +172,7 @@ async def test_see_search() -> None:
 
     # See device for the first time through search.
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
@@ -194,7 +194,7 @@ async def test_see_search_then_alive() -> None:
 
     # See device for the first time through search.
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
@@ -222,13 +222,13 @@ async def test_purge_devices() -> None:
 
     # See device for the first time through alive-advertisement.
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through alive-advertisement.
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
@@ -239,7 +239,7 @@ async def test_purge_devices() -> None:
 
     # See device for the first time through alive-advertisement.
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
-    await search_listener._async_on_data(SEACH_REQUEST_LINE, headers)
+    await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
     callback.assert_awaited()
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 


### PR DESCRIPTION
Properly handle SSDP USN where UDN cannot be derived. Refs #97