### PR TITLE
Don't crash on upnperrors on upnp-client subscribe

### DIFF
--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -17,6 +17,7 @@ from async_upnp_client import UpnpDevice, UpnpFactory, UpnpService, UpnpStateVar
 from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
 from async_upnp_client.const import SsdpHeaders
+from async_upnp_client.exceptions import UpnpResponseError
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
 from async_upnp_client.ssdp import SSDP_PORT, SSDP_ST_ALL, AddressTupleVXType
@@ -269,7 +270,10 @@ async def subscribe(description_url: str, service_names: Any) -> None:
     # subscribe to services
     event_handler = server.event_handler
     for service in services:
-        await event_handler.async_subscribe(service)
+        try:
+            await event_handler.async_subscribe(service)
+        except UpnpResponseError as ex:
+            _LOGGER.error("Unable to subscribe to %s: %s", service, ex)
 
     # keep the webservice running
     while True:


### PR DESCRIPTION
If the subscription fails with some UpnpError (e.g., 405 on sonos beam for qplay service),
log an error instead of crashing.

Example error:
> ERROR:upnp-client:Unable to subscribe to <UpnpService(urn:tencent-com:serviceId:QPlay, uuid:RINCON_542A1B81253701400)>: Did not receive HTTP 200 but 405


Previously:
```
$ upnp-client --pprint subscribe http://192.168.xx.xx:1400/xml/device_description.xml \*

Traceback (most recent call last):
  File "/home/tpr/.virtualenvs/default/bin/upnp-client", line 33, in <module>
    sys.exit(load_entry_point('async-upnp-client', 'console_scripts', 'upnp-client')())
  File "/home/tpr/code/async_upnp_client/async_upnp_client/cli.py", line 370, in main
    loop.run_until_complete(async_main())
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/tpr/code/async_upnp_client/async_upnp_client/cli.py", line 358, in async_main
    await subscribe(args.device, args.service)
  File "/home/tpr/code/async_upnp_client/async_upnp_client/cli.py", line 272, in subscribe
    await event_handler.async_subscribe(service)
  File "/home/tpr/code/async_upnp_client/async_upnp_client/event_handler.py", line 213, in async_subscribe
    raise UpnpResponseError(status=response_status, headers=response_headers)
async_upnp_client.exceptions.UpnpResponseError: Did not receive HTTP 200 but 405

$
```