### PR TITLE
Fix Windows error: `[WinError 10022] An invalid argument was supplied`

### DIFF
--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -242,7 +242,7 @@ def get_ssdp_socket(
             else:
                 _LOGGER.debug("Skipping setting multicast interface")
         else:
-            sock.setsockopt(socket.SOL_IP, socket.IP_MULTICAST_IF, source_ip.packed)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, source_ip.packed)
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
             sock.setsockopt(
                 socket.IPPROTO_IP,


### PR DESCRIPTION
Fix Windows error: `[WinError 10022] An invalid argument was supplied`

Error:
```
C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\Scripts>upnp-client search
Traceback (most recent call last):
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\Scripts\upnp-client-script.py", line 33, in <module>
    sys.exit(load_entry_point('async-upnp-client==0.22.8', 'console_scripts', 'upnp-client')())
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\async_upnp_client\cli.py", line 370, in main
    loop.run_until_complete(async_main())
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.2032.0_x64__qbz5n2kfra8p0\lib\asyncio\base_events.py", line 642, in run_until_complete
    return future.result()
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\async_upnp_client\cli.py", line 360, in async_main
    await search(args)
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\async_upnp_client\cli.py", line 304, in search
    await async_ssdp_search(
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\async_upnp_client\search.py", line 157, in async_search
    await listener.async_start()
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\async_upnp_client\search.py", line 104, in async_start
    sock, source, _ = get_ssdp_socket(
  File "C:\Users\Steven\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\async_upnp_client\ssdp.py", line 245, in get_ssdp_socket
    sock.setsockopt(socket.SOL_IP, socket.IP_MULTICAST_IF, source_ip.packed)
OSError: [WinError 10022] An invalid argument was supplied
```