### PR TITLE
Ignore Cache-Control headers when considering if the headers have changed

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -28,6 +28,7 @@ CACHE_CONTROL_RE = re.compile(r"max-age\s*=\s*(\d+)")
 DEFAULT_MAX_AGE = timedelta(seconds=900)
 IGNORED_HEADERS = {
     "date",
+    "cache-control",
     "server",
 }
 


### PR DESCRIPTION
- Part 1 of fixing home-assistant/core#58142