### PR TITLE
Require specific services for profile devices

### DIFF
--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -210,6 +210,14 @@ class DmrDevice(UpnpProfileDevice):
         "urn:schemas-upnp-org:device:MediaRenderer:3",
     ]
 
+    SERVICE_IDS = frozenset(
+        (
+            "urn:upnp-org:serviceId:AVTransport",
+            "urn:upnp-org:serviceId:ConnectionManager",
+            "urn:upnp-org:serviceId:RenderingControl",
+        )
+    )
+
     _SERVICE_TYPES = {
         "RC": {
             "urn:schemas-upnp-org:service:RenderingControl:3",

--- a/tests/fixtures/dlna/dmr/ConnectionManager_1.xml
+++ b/tests/fixtures/dlna/dmr/ConnectionManager_1.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scpd xmlns="urn:schemas-upnp-org:service-1-0">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <actionList>
+    <action>
+      <name>GetProtocolInfo</name>
+      <argumentList>
+        <argument>
+          <name>Source</name>
+          <direction>out</direction>
+          <relatedStateVariable>SourceProtocolInfo</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>Sink</name>
+          <direction>out</direction>
+          <relatedStateVariable>SinkProtocolInfo</relatedStateVariable>
+        </argument>
+      </argumentList>
+    </action>
+    <action>
+      <name>GetCurrentConnectionIDs</name>
+      <argumentList>
+        <argument>
+          <name>ConnectionIDs</name>
+          <direction>out</direction>
+          <relatedStateVariable>CurrentConnectionIDs</relatedStateVariable>
+        </argument>
+      </argumentList>
+    </action>
+    <action>
+      <name>GetCurrentConnectionInfo</name>
+      <argumentList>
+        <argument>
+          <name>ConnectionID</name>
+          <direction>in</direction>
+          <relatedStateVariable>A_ARG_TYPE_ConnectionID</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>RcsID</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_RcsID</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>AVTransportID</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_AVTransportID</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>ProtocolInfo</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_ProtocolInfo</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>PeerConnectionManager</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_ConnectionManager</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>PeerConnectionID</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_ConnectionID</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>Direction</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_Direction</relatedStateVariable>
+        </argument>
+        <argument>
+          <name>Status</name>
+          <direction>out</direction>
+          <relatedStateVariable>A_ARG_TYPE_ConnectionStatus</relatedStateVariable>
+        </argument>
+      </argumentList>
+    </action>
+  </actionList>
+  <serviceStateTable>
+    <stateVariable sendEvents="yes">
+      <name>SourceProtocolInfo</name>
+      <dataType>string</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="yes">
+      <name>SinkProtocolInfo</name>
+      <dataType>string</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="yes">
+      <name>CurrentConnectionIDs</name>
+      <dataType>string</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_ConnectionStatus</name>
+      <dataType>string</dataType>
+      <allowedValueList>
+        <allowedValue>OK</allowedValue>
+        <allowedValue>ContentFormatMismatch</allowedValue>
+        <allowedValue>InsufficientBandwidth</allowedValue>
+        <allowedValue>UnreliableChannel</allowedValue>
+        <allowedValue>Unknown</allowedValue>
+      </allowedValueList>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_ConnectionManager</name>
+      <dataType>string</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_Direction</name>
+      <dataType>string</dataType>
+      <allowedValueList>
+        <allowedValue>Input</allowedValue>
+        <allowedValue>Output</allowedValue>
+      </allowedValueList>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_ProtocolInfo</name>
+      <dataType>string</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_ConnectionID</name>
+      <dataType>i4</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_AVTransportID</name>
+      <dataType>i4</dataType>
+    </stateVariable>
+    <stateVariable sendEvents="no">
+      <name>A_ARG_TYPE_RcsID</name>
+      <dataType>i4</dataType>
+    </stateVariable>
+  </serviceStateTable>
+</scpd>

--- a/tests/fixtures/dlna/dmr/device_embedded.xml
+++ b/tests/fixtures/dlna/dmr/device_embedded.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0" xmlns:pnpx="http://schemas.microsoft.com/windows/pnpx/2005/11" xmlns:df="http://schemas.microsoft.com/windows/2008/09/devicefoundation" xmlns:sec="http://www.sec.co.kr/dlna">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <device>
+    <deviceType>RootDevice:1</deviceType>
+    <friendlyName>Dummy Root Device</friendlyName>
+    <manufacturer>Steven</manufacturer>
+    <modelDescription>Dummy TV Root device</modelDescription>
+    <modelName>DummyRoot v1</modelName>
+    <UDN>uuid:00000000-0000-0000-0000-000000000000</UDN>
+    <iconList>
+        <icon>
+            <mimetype>image/jpeg</mimetype>
+            <width>48</width>
+            <height>48</height>
+            <depth>24</depth>
+            <url>/device_icon_48.jpg</url>
+        </icon>
+        <icon>
+            <mimetype>image/jpeg</mimetype>
+            <width>120</width>
+            <height>120</height>
+            <depth>24</depth>
+            <url>/device_icon_120.jpg</url>
+        </icon>
+        <icon>
+            <mimetype>image/png</mimetype>
+            <width>48</width>
+            <height>48</height>
+            <depth>24</depth>
+            <url>/device_icon_48.png</url>
+        </icon>
+        <icon>
+            <mimetype>image/png</mimetype>
+            <width>120</width>
+            <height>120</height>
+            <depth>24</depth>
+            <url>/device_icon_120.png</url>
+        </icon>
+    </iconList>
+    <serviceList/>
+    <deviceList>
+      <device>
+        <deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>
+        <friendlyName>Dummy TV</friendlyName>
+        <manufacturer>Steven</manufacturer>
+        <modelDescription>Dummy TV Root device</modelDescription>
+        <modelName>DummyTV v1</modelName>
+        <UDN>uuid:00000000-0000-0000-0000-000000000001</UDN>
+        <serviceList>
+          <service>
+            <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
+            <serviceId>urn:upnp-org:serviceId:RenderingControl</serviceId>
+            <controlURL>/upnp/control/RenderingControl1</controlURL>
+            <eventSubURL>/upnp/event/RenderingControl1</eventSubURL>
+            <SCPDURL>/RenderingControl_1.xml</SCPDURL>
+          </service>
+          <service>
+            <serviceType>urn:schemas-upnp-org:service:ConnectionManager:1</serviceType>
+            <serviceId>urn:upnp-org:serviceId:ConnectionManager</serviceId>
+            <controlURL>/upnp/control/ConnectionManager1</controlURL>
+            <eventSubURL>/upnp/event/ConnectionManager1</eventSubURL>
+            <SCPDURL>/ConnectionManager_1.xml</SCPDURL>
+          </service>
+          <service>
+            <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
+            <serviceId>urn:upnp-org:serviceId:AVTransport</serviceId>
+            <controlURL>/upnp/control/AVTransport1</controlURL>
+            <eventSubURL>/upnp/event/AVTransport1</eventSubURL>
+            <SCPDURL>/AVTransport_1.xml</SCPDURL>
+          </service>
+        </serviceList>
+      </device>
+    </deviceList>
+  </device>
+</root>

--- a/tests/fixtures/dlna/dmr/device_incomplete.xml
+++ b/tests/fixtures/dlna/dmr/device_incomplete.xml
@@ -41,28 +41,6 @@
             <url>/device_icon_120.png</url>
         </icon>
     </iconList>
-    <serviceList>
-      <service>
-        <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
-        <serviceId>urn:upnp-org:serviceId:RenderingControl</serviceId>
-        <controlURL>/upnp/control/RenderingControl1</controlURL>
-        <eventSubURL>/upnp/event/RenderingControl1</eventSubURL>
-        <SCPDURL>/RenderingControl_1.xml</SCPDURL>
-      </service>
-      <service>
-        <serviceType>urn:schemas-upnp-org:service:ConnectionManager:1</serviceType>
-        <serviceId>urn:upnp-org:serviceId:ConnectionManager</serviceId>
-        <controlURL>/upnp/control/ConnectionManager1</controlURL>
-        <eventSubURL>/upnp/event/ConnectionManager1</eventSubURL>
-        <SCPDURL>/ConnectionManager_1.xml</SCPDURL>
-      </service>
-      <service>
-        <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
-        <serviceId>urn:upnp-org:serviceId:AVTransport</serviceId>
-        <controlURL>/upnp/control/AVTransport1</controlURL>
-        <eventSubURL>/upnp/event/AVTransport1</eventSubURL>
-        <SCPDURL>/AVTransport_1.xml</SCPDURL>
-      </service>
-    </serviceList>
+    <serviceList/>
   </device>
 </root>

--- a/tests/upnp_test_requester.py
+++ b/tests/upnp_test_requester.py
@@ -62,10 +62,25 @@ RESPONSE_MAP: Mapping[Tuple[str, str], Tuple[int, Mapping[str, str], str]] = {
         {},
         read_file("dlna/dmr/device.xml"),
     ),
+    ("GET", "http://dlna_dmr:1234/device_embedded.xml"): (
+        200,
+        {},
+        read_file("dlna/dmr/device_embedded.xml"),
+    ),
+    ("GET", "http://dlna_dmr:1234/device_incomplete.xml"): (
+        200,
+        {},
+        read_file("dlna/dmr/device_incomplete.xml"),
+    ),
     ("GET", "http://dlna_dmr:1234/RenderingControl_1.xml"): (
         200,
         {},
         read_file("dlna/dmr/RenderingControl_1.xml"),
+    ),
+    ("GET", "http://dlna_dmr:1234/ConnectionManager_1.xml"): (
+        200,
+        {},
+        read_file("dlna/dmr/ConnectionManager_1.xml"),
     ),
     ("GET", "http://dlna_dmr:1234/AVTransport_1.xml"): (
         200,


### PR DESCRIPTION
The `is_profile_device class` method now requires that a device provides service IDs defined by the `UpnpProfileDevice` subclass to ensure device can be reliably used.

This is used by `DmrDevice` to enforce availability of AVTransport and RenderingControl, without which most methods are unusable.