### PR TITLE
Relax async-timeout dependency, cleanup deprecated sync use

### DIFF
--- a/contrib/dummy_tv.py
+++ b/contrib/dummy_tv.py
@@ -91,7 +91,7 @@ class StateVariable(object):
         for sid, url in SUBSCRIBED_CLIENTS[service_name].items():
             headers = {"SID": sid}
             with ClientSession(loop=asyncio.get_event_loop()) as session:
-                with async_timeout.timeout(10):
+                async with async_timeout.timeout(10):
                     data = DET.ElementTree.tostring(el_notify)
                     LOGGER.debug("Calling: %s", url)
                     yield from session.request(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ PACKAGES = (
 INSTALL_REQUIRES = [
     "voluptuous >= 0.12.1",
     "aiohttp >= 3.7.4",
-    "async-timeout >=3.0, <4.0",
+    "async-timeout >=3.0, <5.0",
     "python-didl-lite ~= 1.3.1",
     "defusedxml >= 0.6.0",
 ]


### PR DESCRIPTION
Relaxes the `async-timeout` dependency.

This resolves this warning in Home Assistant:

```txt
ERROR: Cannot install -r requirements_test_all.txt (line 118), -r requirements_test_all.txt (line 121), -r requirements_test_all.txt (line 158), -r requirements_test_all.txt (line 161), -r requirements_test_all.txt (line 164), -r requirements_test_all.txt (line 203), -r requirements_test_all.txt (line 215), -r requirements_test_all.txt (line 236), -r requirements_test_all.txt (line 24) and -r requirements_test_all.txt (line 54) because these package versions have conflicting dependencies.

The conflict is caused by:
    pyrmvtransport 0.3.2 depends on async-timeout
    adax 0.1.1 depends on async-timeout>=1.4.0
    aioguardian 2021.11.0 depends on async_timeout<5.0.0 and >=3.0.1
    aioharmony 0.2.8 depends on async-timeout
    aiopulse 0.4.2 depends on async_timeout
    aiopvapi 1.6.14 depends on async-timeout
    aiopvpc 2.2.1 depends on async_timeout>=3.0.1
    airthings-cloud 0.0.1 depends on async-timeout
    ambiclimate 0.2.1 depends on async_timeout>=1.4.0
    async-upnp-client 0.22.11 depends on async-timeout<4.0 and >=3.0
    The user requested (constraint) async-timeout==4.0.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

Additionally, removed a single instance that used the context manager sync. Which is deprecated.