### PR TITLE
Allow for renderers that do not provide a list of actions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changes
 
 0.22.13 (unreleased)
 
+- Allow for renderers that do not provide a list of actions. (@Flameeyes)
+
 
 0.22.12 (2021-11-06)
 

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -301,7 +301,7 @@ class UpnpFactory:
         """Create UpnpActions from scpd_el."""
         action_list_el = scpd_el.find("./service:actionList", NS)
         if action_list_el is None:
-            raise UpnpError("Could not find action list element")
+            return []
 
         actions = []
         for action_el in action_list_el.findall("./service:action", NS):


### PR DESCRIPTION
This appears to be the case for Sony HT-A7000 soundbars, which cause
them to become unavailable in Home Assistant right now.
