### PR TITLE
Ignore Link local addresses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 
 - Add new dummy_tv/dummy_router servers (@StevenLooman)
 - Drop python 3.6 support, add python 3.10 support
-- Ignore devices using link local addresses in their location (@Tigger2014)
+- Ignore devices using link local addresses in their location (@Tigger2014, #119)
 
 
 0.23.4 (2022-01-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 
 - Add new dummy_tv/dummy_router servers (@StevenLooman)
 - Drop python 3.6 support, add python 3.10 support
+- Ignore devices using link local addresses in their location (@Tigger2014)
 
 
 0.23.4 (2022-01-16)

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -44,7 +44,7 @@ def valid_search_headers(headers: SsdpHeaders) -> bool:
         and st
         and location
         and location.startswith("http")
-        and not ("://127.0.0.1" in location or "://[::1]" in location)
+        and not ("://127.0.0.1" in location or "://[::1]" in location or "://169.254" in location)
     )
 
 
@@ -61,7 +61,7 @@ def valid_advertisement_headers(headers: SsdpHeaders) -> bool:
         and nts
         and location
         and location.startswith("http")
-        and not ("://127.0.0.1" in location or "://[::1]" in location)
+        and not ("://127.0.0.1" in location or "://[::1]" in location or "://169.254" in location)
     )
 
 

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -397,6 +397,7 @@ async def test_see_search_invalid_location() -> None:
     [
         "http://127.0.0.1:1234/device.xml",
         "http://[::1]:1234/device.xml",
+        "http://169.254.12.1:1234/device.xml",
     ],
 )
 async def test_see_search_localhost_location(location: str) -> None:


### PR DESCRIPTION
I have a couple of devices that end up suggesting their link local addresses via SSDP and not there actual IP. Ignore theses addresses.