### PR TITLE
Don't trigger SSDP-change from searches/advertisements by known dual-stack devices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changes
 =======
 
-0.24.1 (unreleased)
+0.25.0 (unreleased)
 
 - Better handle multi-stack devices by de-duplicating search responses/advertisements from different IP versions in `SsdpListener`
   - Use the parameter `device_tracker` to share the `SsdpDeviceTracker` between `SsdpListener`s monitoring the same network
+  - Note that the `SsdpDeviceTracker` is now locked by the `SsdpListener` in case it is shared.
 
 
 0.24.0 (2022-02-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Changes
 
 0.24.1 (unreleased)
 
+- Better handle multi-stack devices by de-duplicating search responses/advertisements from different IP versions in `SsdpListener`
+  - Use the parameter `device_tracker` to share the `SsdpDeviceTracker` between `SsdpListener`s monitoring the same network
+
 
 0.24.0 (2022-02-12)
 

--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -50,7 +50,11 @@ class SsdpAdvertisementListener:
             _LOGGER.debug("Got non-advertisement packet: %s, %s", request_line, headers)
             return
 
-        _LOGGER.debug("Received advertisement, USN: %s", headers.get("USN", "<no USN>"))
+        _LOGGER.debug(
+            "Received advertisement, USN: %s, location: %s",
+            headers.get("USN", "<no USN>"),
+            headers.get("location", ""),
+        )
 
         headers["_source"] = SsdpSource.ADVERTISEMENT
         notification_sub_type = headers["NTS"]

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -71,7 +71,11 @@ class SsdpSearchListener:  # pylint: disable=too-many-arguments,too-many-instanc
             )
             return
 
-        _LOGGER.debug("Received response, USN: %s", headers.get("USN", "<no USN>"))
+        _LOGGER.debug(
+            "Received advertisement, USN: %s, location: %s",
+            headers.get("USN", "<no USN>"),
+            headers.get("location", ""),
+        )
         headers["_source"] = SsdpSource.SEARCH
         if self._target_host and self._target_host != headers["_host"]:
             return

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -91,6 +91,16 @@ def get_adjusted_url(url: str, addr: AddressTupleVXType) -> str:
     return urlunsplit(data._replace(netloc=netloc))
 
 
+def is_ipv4_address(addr: AddressTupleVXType) -> bool:
+    """Test if addr is a IPv4 tuple."""
+    return len(addr) == 2
+
+
+def is_ipv6_address(addr: AddressTupleVXType) -> bool:
+    """Test if addr is a IPv6 tuple."""
+    return len(addr) == 4
+
+
 def build_ssdp_packet(status_line: str, headers: SsdpHeaders) -> bytes:
     """Construct a SSDP packet."""
     headers_str = "\r\n".join([f"{key}:{value}" for key, value in headers.items()])

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ TEST_REQUIRES = [
 
 setup(
     name="async_upnp_client",
-    version="0.24.1.dev0",
+    version="0.25.0.dev0",
     description="Async UPnP Client",
     long_description=LONG_DESCRIPTION,
     url="https://github.com/StevenLooman/async_upnp_client",

--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -16,6 +16,8 @@ from async_upnp_client.ssdp import (
     build_ssdp_search_packet,
     decode_ssdp_packet,
     get_ssdp_socket,
+    is_ipv4_address,
+    is_ipv6_address,
     is_valid_ssdp_packet,
 )
 
@@ -255,3 +257,15 @@ def test_microsoft_butchers_ssdp() -> None:
         "_remote_addr": ("192.168.1.1", 12345),
         "_timestamp": ANY,
     }
+
+
+def test_is_ipv4_address() -> None:
+    """Test is_ipv4_address()."""
+    assert is_ipv4_address(("192.168.1.1", 12345))
+    assert not is_ipv4_address(("fe80::1", 12345, 0, 6))
+
+
+def test_is_ipv6_address() -> None:
+    """Test is_ipv6_address()."""
+    assert is_ipv6_address(("fe80::1", 12345, 0, 6))
+    assert not is_ipv6_address(("192.168.1.1", 12345))

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -70,10 +70,15 @@ async def test_see_advertisement_alive() -> None:
     assert advertisement_listener is not None
 
     # See device for the first time through alive-advertisement.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_ALIVE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through alive-advertisement, not triggering callback.
@@ -110,7 +115,11 @@ async def test_see_advertisement_byebye() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited_once()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_ALIVE,
+    )
     assert callback.await_args is not None
     device, dst, _ = callback.await_args.args
     assert device.combined_headers(dst)["NTS"] == "ssdp:alive"
@@ -121,7 +130,11 @@ async def test_see_advertisement_byebye() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_BYEBYE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited_once()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_BYEBYE,
+    )
     assert callback.await_args is not None
     device, dst, _ = callback.await_args.args
     assert device.combined_headers(dst)["NTS"] == "ssdp:byebye"
@@ -145,7 +158,11 @@ async def test_see_advertisement_update() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_ALIVE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_ALIVE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through update-advertisement, triggering callback.
@@ -154,7 +171,11 @@ async def test_see_advertisement_update() -> None:
     headers["NTS"] = NotificationSubType.SSDP_UPDATE
     headers["BOOTID.UPNP.ORG"] = "2"
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_UPDATE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     await listener.async_stop()
@@ -171,9 +192,25 @@ async def test_see_search() -> None:
     assert search_listener is not None
 
     # See device for the first time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_CHANGED,
+    )
+    assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
+
+    # See same device again through search, not triggering a change.
+    callback.reset_mock()
+    headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
+    await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
+    callback.assert_awaited_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_ALIVE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     await listener.async_stop()
@@ -192,9 +229,14 @@ async def test_see_search_then_alive() -> None:
     assert search_listener is not None
 
     # See device for the first time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_CHANGED,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through alive-advertisement, not triggering callback.
@@ -221,9 +263,14 @@ async def test_see_search_then_update() -> None:
     assert search_listener is not None
 
     # See device for the first time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_CHANGED,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through update-advertisement, triggering callback.
@@ -231,7 +278,11 @@ async def test_see_search_then_update() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_UPDATE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_UPDATE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     await listener.async_stop()
@@ -250,9 +301,14 @@ async def test_see_search_then_byebyee() -> None:
     assert search_listener is not None
 
     # See device for the first time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_CHANGED,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # See device for the second time through byebye-advertisement,
@@ -261,7 +317,11 @@ async def test_see_search_then_byebyee() -> None:
     headers = CaseInsensitiveDict(ADVERTISEMENT_HEADERS_DEFAULT)
     headers["NTS"] = NotificationSubType.SSDP_BYEBYE
     await advertisement_listener._async_on_data(ADVERTISEMENT_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.ADVERTISEMENT_BYEBYE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] not in listener.devices
 
     await listener.async_stop()
@@ -277,30 +337,47 @@ async def test_purge_devices() -> None:
     search_listener = listener._search_listener
     assert search_listener is not None
 
-    # See device for the first time through alive-advertisement.
+    # See device for the first time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_CHANGED,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
-    # See device for the second time through alive-advertisement.
+    # See device for the second time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_ALIVE,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # "Wait" a bit... and purge devices.
+    callback.reset_mock()
     override_now = headers["_timestamp"] + timedelta(hours=1)
     listener._device_tracker.purge_devices(override_now)
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] not in listener.devices
 
-    # See device for the first time through alive-advertisement.
+    # See device for the first time through search.
+    callback.reset_mock()
     headers = CaseInsensitiveDict(SEARCH_HEADERS_DEFAULT)
     await search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-    callback.assert_awaited()
+    callback.assert_awaited_once_with(
+        ANY,
+        "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
+        SsdpSource.SEARCH_CHANGED,
+    )
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] in listener.devices
 
     # "Wait" a bit... and purge devices again.
+    callback.reset_mock()
     override_now = headers["_timestamp"] + timedelta(hours=1)
     listener._device_tracker.purge_devices(override_now)
     assert ADVERTISEMENT_HEADERS_DEFAULT["_udn"] not in listener.devices
@@ -480,7 +557,8 @@ async def test_see_search_device_ipv4_and_ipv6() -> None:
     listener = SsdpListener(async_callback=callback)
     await listener.async_start()
 
-    # See device via IPv4.
+    # See device via IPv4, callback should be called.
+    callback.reset_mock()
     location_ipv4 = "http://192.168.1.1:80/RootDevice.xml"
     headers = CaseInsensitiveDict(
         {
@@ -490,14 +568,13 @@ async def test_see_search_device_ipv4_and_ipv6() -> None:
     )
     assert listener._search_listener is not None
     await listener._search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-
-    # Ensure callback was called.
     callback.assert_awaited_once_with(
         ANY, SEARCH_HEADERS_DEFAULT["ST"], SsdpSource.SEARCH_CHANGED
     )
-    callback.reset_mock()
 
-    # See device via IPv6.
+    # See device via IPv6, callback should be called with SsdpSource.SEARCH_ALIVE,
+    # not SEARCH_UPDATE.
+    callback.reset_mock()
     location_ipv6 = "http://[fe80::1]:80/RootDevice.xml"
     headers = CaseInsensitiveDict(
         {
@@ -506,11 +583,8 @@ async def test_see_search_device_ipv4_and_ipv6() -> None:
         }
     )
     await listener._search_listener._async_on_data(SEARCH_REQUEST_LINE, headers)
-
-    # Ensure callback was NOT called. It is the same device, just from IPv6 instead of IPv4.
     callback.assert_awaited_once_with(
         ANY, SEARCH_HEADERS_DEFAULT["ST"], SsdpSource.SEARCH_ALIVE
     )
-    callback.reset_mock()
 
     assert listener.devices[SEARCH_HEADERS_DEFAULT["_udn"]].locations


### PR DESCRIPTION
Don't trigger SSDP-change from searches/advertisements by known dual-stack devices. This compares the `location` header from advertisements/search results and prevents a `SsdpSource.SEARCH_CHANGED` when comparing headers from a advertisement/search response IPv4 against a IPv6 advertisement/search response .