### PR TITLE
DMR will fetch state variables when initially connecting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changes
 
 0.25.1 (unreleased)
 
+- Poll DLNA DMR state variables when first connecting (@chishm)
+- Add CurrentTransportActions to list of state variables to poll when DLNA DMR device is not successfully subscribed (@chishm)
 
 0.25.0 (2022-02-22)
 


### PR DESCRIPTION
Similar to DMS, this polls for certain state variables when first connecting, to ensure they're available even if subscription events haven't come back yet.