### PR TITLE
Always use CaseInsensitiveDict for headers

### DIFF
--- a/async_upnp_client/advertisement.py
+++ b/async_upnp_client/advertisement.py
@@ -11,11 +11,11 @@ from typing import Awaitable, Callable, Optional
 from async_upnp_client.const import AddressTupleVXType, NotificationSubType, SsdpSource
 from async_upnp_client.ssdp import (
     SSDP_DISCOVER,
-    SsdpHeaders,
     SsdpProtocol,
     determine_source_target,
     get_ssdp_socket,
 )
+from async_upnp_client.utils import CaseInsensitiveDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,9 +25,9 @@ class SsdpAdvertisementListener:
 
     def __init__(
         self,
-        on_alive: Optional[Callable[[SsdpHeaders], Awaitable]] = None,
-        on_byebye: Optional[Callable[[SsdpHeaders], Awaitable]] = None,
-        on_update: Optional[Callable[[SsdpHeaders], Awaitable]] = None,
+        on_alive: Optional[Callable[[CaseInsensitiveDict], Awaitable]] = None,
+        on_byebye: Optional[Callable[[CaseInsensitiveDict], Awaitable]] = None,
+        on_update: Optional[Callable[[CaseInsensitiveDict], Awaitable]] = None,
         source: Optional[AddressTupleVXType] = None,
         target: Optional[AddressTupleVXType] = None,
         loop: Optional[AbstractEventLoop] = None,
@@ -41,7 +41,9 @@ class SsdpAdvertisementListener:
         self._loop: AbstractEventLoop = loop or asyncio.get_event_loop()
         self._transport: Optional[BaseTransport] = None
 
-    async def _async_on_data(self, request_line: str, headers: SsdpHeaders) -> None:
+    async def _async_on_data(
+        self, request_line: str, headers: CaseInsensitiveDict
+    ) -> None:
         """Handle data."""
         if headers.get("MAN") == SSDP_DISCOVER:
             # Ignore discover packets.

--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -16,12 +16,12 @@ from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
 from async_upnp_client.client import UpnpDevice, UpnpService, UpnpStateVariable
 from async_upnp_client.client_factory import UpnpFactory
-from async_upnp_client.const import AddressTupleVXType, SsdpHeaders
+from async_upnp_client.const import AddressTupleVXType
 from async_upnp_client.exceptions import UpnpResponseError
 from async_upnp_client.profiles.dlna import dlna_handle_notify_last_change
 from async_upnp_client.search import async_search as async_ssdp_search
 from async_upnp_client.ssdp import SSDP_IP_V4, SSDP_IP_V6, SSDP_PORT, SSDP_ST_ALL
-from async_upnp_client.utils import get_local_ip
+from async_upnp_client.utils import CaseInsensitiveDict, get_local_ip
 
 logging.basicConfig()
 _LOGGER = logging.getLogger("upnp-client")
@@ -364,9 +364,13 @@ async def search(search_args: Any) -> None:
         search_args.bind, search_args.target, search_args.target_port
     )
 
-    async def on_response(headers: SsdpHeaders) -> None:
-        headers = {key: str(value) for key, value in headers.items()}
-        print(json.dumps(headers, indent=pprint_indent))
+    async def on_response(headers: CaseInsensitiveDict) -> None:
+        print(
+            json.dumps(
+                {key: str(value) for key, value in headers.items()},
+                indent=pprint_indent,
+            )
+        )
 
     await async_ssdp_search(
         service_type=service_type,
@@ -385,9 +389,13 @@ async def advertisements(advertisement_args: Any) -> None:
         advertisement_args.target_port,
     )
 
-    async def on_notify(headers: SsdpHeaders) -> None:
-        headers = {key: str(value) for key, value in headers.items()}
-        print(json.dumps(headers, indent=pprint_indent))
+    async def on_notify(headers: CaseInsensitiveDict) -> None:
+        print(
+            json.dumps(
+                {key: str(value) for key, value in headers.items()},
+                indent=pprint_indent,
+            )
+        )
 
     listener = SsdpAdvertisementListener(
         on_alive=on_notify,

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -29,7 +29,6 @@ from async_upnp_client.const import (
     DeviceIcon,
     DeviceInfo,
     ServiceInfo,
-    SsdpHeaders,
     StateVariableInfo,
 )
 from async_upnp_client.exceptions import (
@@ -109,7 +108,7 @@ class UpnpDevice:
             embedded_device.parent_device = self
 
         # SSDP headers.
-        self.ssdp_headers: SsdpHeaders = CaseInsensitiveDict()
+        self.ssdp_headers: CaseInsensitiveDict = CaseInsensitiveDict()
 
         # Just initialized, mark available.
         self.available = True

--- a/async_upnp_client/device_updater.py
+++ b/async_upnp_client/device_updater.py
@@ -7,7 +7,8 @@ from typing import Optional
 from async_upnp_client.advertisement import SsdpAdvertisementListener
 from async_upnp_client.client import UpnpDevice
 from async_upnp_client.client_factory import UpnpFactory
-from async_upnp_client.const import AddressTupleVXType, SsdpHeaders
+from async_upnp_client.const import AddressTupleVXType
+from async_upnp_client.utils import CaseInsensitiveDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class DeviceUpdater:
         _LOGGER.debug("Stop listening for notifications.")
         await self._listener.async_stop()
 
-    async def _on_alive(self, headers: SsdpHeaders) -> None:
+    async def _on_alive(self, headers: CaseInsensitiveDict) -> None:
         """Handle on alive."""
         # Ensure for root devices only.
         if headers.get("nt") != "upnp:rootdevice":
@@ -61,12 +62,12 @@ class DeviceUpdater:
         _LOGGER.debug("Handling alive: %s", headers)
         await self._async_handle_alive_update(headers)
 
-    async def _on_byebye(self, headers: SsdpHeaders) -> None:
+    async def _on_byebye(self, headers: CaseInsensitiveDict) -> None:
         """Handle on byebye."""
         _LOGGER.debug("Handling on_byebye: %s", headers)
         self._device.available = False
 
-    async def _on_update(self, headers: SsdpHeaders) -> None:
+    async def _on_update(self, headers: CaseInsensitiveDict) -> None:
         """Handle on update."""
         # Ensure for root devices only.
         if headers.get("nt") != "upnp:rootdevice":
@@ -79,7 +80,7 @@ class DeviceUpdater:
         _LOGGER.debug("Handling update: %s", headers)
         await self._async_handle_alive_update(headers)
 
-    async def _async_handle_alive_update(self, headers: SsdpHeaders) -> None:
+    async def _async_handle_alive_update(self, headers: CaseInsensitiveDict) -> None:
         """Handle on_alive or on_update."""
         do_reinit = False
 
@@ -115,7 +116,9 @@ class DeviceUpdater:
         # We heard from it, so mark it available.
         self._device.available = True
 
-    async def _reinit_device(self, location: str, ssdp_headers: SsdpHeaders) -> None:
+    async def _reinit_device(
+        self, location: str, ssdp_headers: CaseInsensitiveDict
+    ) -> None:
         """Reinitialize device."""
         # pylint: disable=protected-access
         _LOGGER.debug("Reinitializing device, location: %s", location)

--- a/async_upnp_client/profiles/profile.py
+++ b/async_upnp_client/profiles/profile.py
@@ -15,7 +15,7 @@ from async_upnp_client.client import (
     UpnpStateVariable,
     UpnpValueError,
 )
-from async_upnp_client.const import AddressTupleVXType, SsdpHeaders
+from async_upnp_client.const import AddressTupleVXType
 from async_upnp_client.event_handler import UpnpEventHandler
 from async_upnp_client.exceptions import (
     UpnpConnectionError,
@@ -24,6 +24,7 @@ from async_upnp_client.exceptions import (
 )
 from async_upnp_client.search import async_search
 from async_upnp_client.ssdp import SSDP_MX
+from async_upnp_client.utils import CaseInsensitiveDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ class UpnpProfileDevice:
     @classmethod
     async def async_search(
         cls, source: Optional[AddressTupleVXType] = None, timeout: int = SSDP_MX
-    ) -> Set[SsdpHeaders]:
+    ) -> Set[CaseInsensitiveDict]:
         """
         Search for this device type.
 
@@ -71,7 +72,7 @@ class UpnpProfileDevice:
         """
         responses = set()
 
-        async def on_response(data: SsdpHeaders) -> None:
+        async def on_response(data: CaseInsensitiveDict) -> None:
             if "st" in data and data["st"] in cls.DEVICE_TYPES:
                 responses.add(data)
 
@@ -80,7 +81,7 @@ class UpnpProfileDevice:
         return responses
 
     @classmethod
-    async def async_discover(cls) -> Set[SsdpHeaders]:
+    async def async_discover(cls) -> Set[CaseInsensitiveDict]:
         """Alias for async_search."""
         return await cls.async_search()
 

--- a/async_upnp_client/search.py
+++ b/async_upnp_client/search.py
@@ -15,13 +15,13 @@ from async_upnp_client.ssdp import (
     SSDP_ST_ALL,
     AddressTupleVXType,
     IPvXAddress,
-    SsdpHeaders,
     SsdpProtocol,
     build_ssdp_search_packet,
     determine_source_target,
     get_host_string,
     get_ssdp_socket,
 )
+from async_upnp_client.utils import CaseInsensitiveDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class SsdpSearchListener:  # pylint: disable=too-many-arguments,too-many-instanc
 
     def __init__(
         self,
-        async_callback: Callable[[SsdpHeaders], Awaitable],
+        async_callback: Callable[[CaseInsensitiveDict], Awaitable],
         loop: Optional[AbstractEventLoop] = None,
         source: Optional[AddressTupleVXType] = None,
         target: Optional[AddressTupleVXType] = None,
@@ -61,7 +61,9 @@ class SsdpSearchListener:  # pylint: disable=too-many-arguments,too-many-instanc
         target = override_target or self.target
         protocol.send_ssdp_packet(packet, target)
 
-    async def _async_on_data(self, request_line: str, headers: SsdpHeaders) -> None:
+    async def _async_on_data(
+        self, request_line: str, headers: CaseInsensitiveDict
+    ) -> None:
         """Handle data."""
         if headers.get("MAN") == SSDP_DISCOVER:
             # Ignore discover packets.
@@ -128,7 +130,7 @@ class SsdpSearchListener:  # pylint: disable=too-many-arguments,too-many-instanc
 
 
 async def async_search(
-    async_callback: Callable[[SsdpHeaders], Awaitable],
+    async_callback: Callable[[CaseInsensitiveDict], Awaitable],
     timeout: int = SSDP_MX,
     service_type: str = SSDP_ST_ALL,
     source: Optional[AddressTupleVXType] = None,

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -136,7 +136,7 @@ def is_valid_ssdp_packet(data: bytes) -> bool:
 
 
 def udn_from_headers(
-    headers: Union[CIMultiDictProxy, SsdpHeaders]
+    headers: Union[CIMultiDictProxy, CaseInsensitiveDict]
 ) -> Optional[UniqueDeviceName]:
     """Get UDN from USN in headers."""
     usn = headers.get("usn", "")
@@ -191,7 +191,7 @@ class SsdpProtocol(DatagramProtocol):
         self,
         loop: AbstractEventLoop,
         on_connect: Optional[Callable[[DatagramTransport], Awaitable]] = None,
-        on_data: Optional[Callable[[str, SsdpHeaders], Awaitable]] = None,
+        on_data: Optional[Callable[[str, CaseInsensitiveDict], Awaitable]] = None,
     ) -> None:
         """Initialize."""
         self.loop = loop

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -17,7 +17,6 @@ from voluptuous import Invalid
 
 EXTERNAL_IP = "1.1.1.1"
 EXTERNAL_PORT = 80
-_LOGGER = logging.getLogger(__name__)
 
 
 class CaseInsensitiveDict(abcMutableMapping):

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -2,7 +2,6 @@
 """async_upnp_client.utils module."""
 
 import asyncio
-import logging
 import re
 import socket
 from collections import defaultdict

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -2,6 +2,7 @@
 """async_upnp_client.utils module."""
 
 import asyncio
+import logging
 import re
 import socket
 from collections import defaultdict
@@ -17,6 +18,7 @@ from voluptuous import Invalid
 
 EXTERNAL_IP = "1.1.1.1"
 EXTERNAL_PORT = 80
+_LOGGER = logging.getLogger(__name__)
 
 
 class CaseInsensitiveDict(abcMutableMapping):
@@ -34,6 +36,10 @@ class CaseInsensitiveDict(abcMutableMapping):
     def as_lower_dict(self) -> Dict[str, Any]:
         """Return the underlying dict in lowercase."""
         return {k.lower(): v for k, v in self._data.items()}
+
+    def get_lower(self, lower_key: str) -> Any:
+        """Get a lower case key."""
+        return self._data[self._case_map[lower_key]]
 
     def replace(self, new_data: abcMapping) -> None:
         """Replace the underlying dict."""

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -39,7 +39,9 @@ class CaseInsensitiveDict(abcMutableMapping):
 
     def get_lower(self, lower_key: str) -> Any:
         """Get a lower case key."""
-        return self._data[self._case_map[lower_key]]
+        if lower_key in self._case_map:
+            return self._data[self._case_map[lower_key]]
+        return None
 
     def replace(self, new_data: abcMapping) -> None:
         """Replace the underlying dict."""

--- a/contrib/server.py
+++ b/contrib/server.py
@@ -37,7 +37,6 @@ from async_upnp_client.const import (
     AddressTupleVXType,
     DeviceInfo,
     ServiceInfo,
-    SsdpHeaders,
     StateVariableInfo,
     StateVariableTypeInfo,
 )
@@ -55,6 +54,7 @@ from async_upnp_client.ssdp import (
     determine_source_target,
     get_ssdp_socket,
 )
+from async_upnp_client.utils import CaseInsensitiveDict
 
 NAMESPACES = {
     "s": "http://schemas.xmlsoap.org/soap/envelope/",
@@ -84,7 +84,7 @@ class SsdpSearchResponder:
     async def _async_on_data(
         self,
         request_line: str,
-        headers: SsdpHeaders,
+        headers: CaseInsensitiveDict,
     ) -> None:
         """Handle data."""
         assert self._transport
@@ -193,7 +193,7 @@ class SsdpSearchResponder:
         protocol.send_ssdp_packet(packet, remote_addr)
 
 
-def _build_advertisements(root_device: "UpnpServerDevice") -> List[SsdpHeaders]:
+def _build_advertisements(root_device: "UpnpServerDevice") -> List[CaseInsensitiveDict]:
     """Build advertisements to be sent for a UpnpDevice."""
     # 3 + 2d + k (d: embedded device, k: service)
     # global:      ST: upnp:rootdevice
@@ -204,7 +204,7 @@ def _build_advertisements(root_device: "UpnpServerDevice") -> List[SsdpHeaders]:
     #              USN: uuid:device-UUID::urn:schemas-upnp-org:device:deviceType:ver
     # per service: ST: urn:schemas-upnp-org:service:serviceType:ver
     #              USN: uuid:device-UUID::urn:schemas-upnp-org:service:serviceType:ver
-    advertisements: List[SsdpHeaders] = []
+    advertisements: List[CaseInsensitiveDict] = []
 
     base_headers = {
         "NTS": "ssdp:alive",


### PR DESCRIPTION
This is a breaking change due to the typing change.

`same_headers_differ` is big remaining hotspot in the code

<img width="575" alt="Screen Shot 2022-04-24 at 10 10 42" src="https://user-images.githubusercontent.com/663432/164994730-c1c5578c-ffed-458f-9ae4-b16779ad83c4.png">



- Headers were typed to not always be a CaseInsensitiveDict but
  in practice they always were. By ensuring they are always a
  CaseInsensitiveDict we can reduce the number of string
  transforms since we already know when strings have been
  lowercased

