### PR TITLE
Gracefully handle bad Get* state variable actions

### DIFF
--- a/async_upnp_client/profiles/profile.py
+++ b/async_upnp_client/profiles/profile.py
@@ -431,8 +431,25 @@ class UpnpProfileDevice:
         changed_state_variables: List[UpnpStateVariable] = []
 
         for action_name in action_names:
-            action = service.action(action_name)
-            result = await action.async_call(**in_args)
+            try:
+                action = service.action(action_name)
+            except KeyError:
+                _LOGGER.debug(
+                    "Can't poll missing action %s:%s for state variables",
+                    service_name,
+                    action_name,
+                )
+                continue
+            try:
+                result = await action.async_call(**in_args)
+            except UpnpResponseError as err:
+                _LOGGER.debug(
+                    "Failed to call action %s:%s for state variables: %r",
+                    service_name,
+                    action_name,
+                    err,
+                )
+                continue
 
             for arg in action.arguments:
                 if arg.direction != "out":


### PR DESCRIPTION
Some devices don't support all the Get* actions (e.g. `GetTransportSettings`) that return state variables. This could cause
exceptions when trying to poll variables during an (initial) update. Now when an expected (state variable polling) action is missing, or gives a response error, it is logged but no exception is raised.

This should hopefully fix https://github.com/home-assistant/core/issues/70611 and https://github.com/home-assistant/core/issues/71306 .

All tests pass except for on Python 3.10, where I can't get past the tox install step (`ModuleNotFoundError: No module named 'distutils.command.bdist_wininst'`). I'm confident it should work there too, though.