### PR TITLE
Work around aiohttp sending invalid Host-header

### DIFF
--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -29,6 +29,9 @@ _LOGGER_TRAFFIC_UPNP = logging.getLogger("async_upnp_client.traffic.upnp")
 
 def _fixed_host_header(url: str) -> Dict[str, str]:
     """Strip scope_id from IPv6 host, if needed."""
+    if "%" not in url:
+        return {}
+
     url_parts = urlparse(url)
     if url_parts.hostname and "%" in url_parts.hostname:
         idx = url_parts.hostname.rindex("%")

--- a/changes/138.bugfix
+++ b/changes/138.bugfix
@@ -1,0 +1,1 @@
+Work around aiohttp sending invalid Host-header. When the device url contains a IPv6-address host with scope_id, aiohttp sends the scope_id with the Host-header. This causes problems with some devices, returning a HTTP 404 error or perhaps a HTTP 400 error.

--- a/changes/138.bugfix
+++ b/changes/138.bugfix
@@ -1,1 +1,4 @@
-Work around aiohttp sending invalid Host-header. When the device url contains a IPv6-address host with scope_id, aiohttp sends the scope_id with the Host-header. This causes problems with some devices, returning a HTTP 404 error or perhaps a HTTP 400 error.
+Work around aiohttp sending invalid Host-header. When the device url contains
+a IPv6-addresshost with scope_id, aiohttp sends the scope_id with the
+Host-header. This causes problems with some devices, returning a HTTP 404
+error or perhaps a HTTP 400 error.

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -5,10 +5,32 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpRequester
+from async_upnp_client.aiohttp import (
+    AiohttpNotifyServer,
+    AiohttpRequester,
+    _fixed_host_header,
+)
 from async_upnp_client.exceptions import UpnpCommunicationError
 
 from .conftest import RESPONSE_MAP, UpnpTestRequester
+
+
+def test_fixed_host_header() -> None:
+    """Test _fixed_host_header."""
+    # pylint: disable=C1803
+    assert _fixed_host_header("http://192.168.1.1:8000/desc") == {}
+    assert _fixed_host_header("http://router.local:8000/desc") == {}
+    assert _fixed_host_header("http://[fe80::1%10]:8000/desc") == {
+        "Host": "[fe80::1]:8000"
+    }
+
+    assert _fixed_host_header("http://192.168.1.1/desc") == {}
+    assert _fixed_host_header("http://router.local/desc") == {}
+    assert _fixed_host_header("http://[fe80::1%10]/desc") == {"Host": "[fe80::1]"}
+
+    assert _fixed_host_header("https://192.168.1.1/desc") == {}
+    assert _fixed_host_header("https://router.local/desc") == {}
+    assert _fixed_host_header("https://[fe80::1%10]/desc") == {"Host": "[fe80::1]"}
 
 
 def test_server_init() -> None:

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -32,6 +32,10 @@ def test_fixed_host_header() -> None:
     assert _fixed_host_header("https://router.local/desc") == {}
     assert _fixed_host_header("https://[fe80::1%10]/desc") == {"Host": "[fe80::1]"}
 
+    assert _fixed_host_header("http://192.168.1.1:8000/root%desc") == {}
+    assert _fixed_host_header("http://router.local:8000/root%desc") == {}
+    assert _fixed_host_header("http://[fe80::1]:8000/root%desc") == {}
+
 
 def test_server_init() -> None:
     """Test initialization of an AiohttpNotifyServer."""


### PR DESCRIPTION
Work around aiohttp sending invalid Host-header. When the device url contains a IPv6-address host with `scope_id`, `aiohttp` sends the `scope_id` with the `Host`-header. This causes problems with some devices, returning a HTTP 404 error or perhaps a HTTP 400 error.

For example, a device responds/advertises it is reachable at `http://fe80::1:2:3:4%2:5000/rootDesc.xml`. The URL is passed to the `UpnpFactory.async_create_device` method. `aiohttp` then does a GET request to `http://fe80::1:2:3:4%2:5000/rootDesc.xml`. In case of a Compal Broadband Networks router (provided by Ziggo/Liberty Global), it returns a HTTP 404.

This fix strips the `scope_id` from the address, causing the router to properly reply to HTTP requests.