### PR TITLE
Fix AiohttpSessionRequester disconnections

### DIFF
--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -108,9 +108,9 @@ class AiohttpRequester(UpnpRequester):
 
                         resp_body_text = await response.text()
         except asyncio.TimeoutError as err:
-            raise UpnpConnectionTimeoutError(str(err)) from err
+            raise UpnpConnectionTimeoutError(repr(err)) from err
         except aiohttp.ClientConnectionError as err:
-            raise UpnpConnectionError(str(err)) from err
+            raise UpnpConnectionError(repr(err)) from err
         except aiohttp.ClientResponseError as err:
             raise UpnpClientResponseError(
                 request_info=err.request_info,
@@ -120,9 +120,9 @@ class AiohttpRequester(UpnpRequester):
                 headers=err.headers,
             ) from err
         except aiohttp.ClientError as err:
-            raise UpnpCommunicationError(str(err)) from err
+            raise UpnpCommunicationError(repr(err)) from err
         except UnicodeDecodeError as err:
-            raise UpnpCommunicationError(str(err)) from err
+            raise UpnpCommunicationError(repr(err)) from err
 
         return status, resp_headers, resp_body_text
 
@@ -221,7 +221,7 @@ class AiohttpSessionRequester(UpnpRequester):
 
                     resp_body_text = await response.text()
         except asyncio.TimeoutError as err:
-            raise UpnpConnectionTimeoutError(str(err)) from err
+            raise UpnpConnectionTimeoutError(repr(err)) from err
         except aiohttp.ServerDisconnectedError:
             raise
         except aiohttp.ClientConnectionError as err:
@@ -235,9 +235,9 @@ class AiohttpSessionRequester(UpnpRequester):
                 headers=err.headers,
             ) from err
         except aiohttp.ClientError as err:
-            raise UpnpCommunicationError(str(err)) from err
+            raise UpnpCommunicationError(repr(err)) from err
         except UnicodeDecodeError as err:
-            raise UpnpCommunicationError(str(err)) from err
+            raise UpnpCommunicationError(repr(err)) from err
 
         return status, resp_headers, resp_body_text
 

--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -164,12 +164,12 @@ class AiohttpSessionRequester(UpnpRequester):
         for _ in range(2):
             try:
                 return await self._async_http_request(method, url, headers, body)
-            except aiohttp.ServerDisconnectedError as err:
+            except aiohttp.ClientConnectionError as err:
                 _LOGGER.debug("%r during request; retrying", err)
         try:
             return await self._async_http_request(method, url, headers, body)
-        except aiohttp.ServerDisconnectedError as err:
-            raise UpnpConnectionError(str(err)) from err
+        except aiohttp.ClientConnectionError as err:
+            raise UpnpConnectionError(repr(err)) from err
 
     async def _async_http_request(
         self,
@@ -222,10 +222,8 @@ class AiohttpSessionRequester(UpnpRequester):
                     resp_body_text = await response.text()
         except asyncio.TimeoutError as err:
             raise UpnpConnectionTimeoutError(repr(err)) from err
-        except aiohttp.ServerDisconnectedError:
+        except aiohttp.ClientConnectionError:
             raise
-        except aiohttp.ClientConnectionError as err:
-            raise UpnpConnectionError(str(err)) from err
         except aiohttp.ClientResponseError as err:
             raise UpnpClientResponseError(
                 request_info=err.request_info,

--- a/changes/139.bugfix
+++ b/changes/139.bugfix
@@ -1,0 +1,7 @@
+Fix errors raised when `AiohttpSessionRequester` is disconnected while writing a request body.
+
+The server is allowed to disconnect at any time during a request session, which point we want to retry the request.
+
+A disconnection could manifest as an `aiohttp.ServerDisconnectedError` if it happened between requests, or it could be `aiohttp.ClientOSError` if it happened while we are writing the request body. Both errors derive from `aiohttp.ClientConnectionError` for socket errors.
+
+Also use `repr` when encapsulating errors for easier debugging.


### PR DESCRIPTION
The server is allowed to disconnect at any time during a request session, which point we want to retry the request.

A disconnection could manifest as an `aiohttp.ServerDisconnectedError` if it happened between requests, or it could be `aiohttp.ClientOSError` if it happened while we are writing the request body. Both errors derive from `aiohttp.ClientConnectionError` for socket errors.

Also use `repr` when encapsulating errors for easier debugging.