### PR TITLE
Ignore host header, otherwise triggering a changed device from SsdpListener

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -33,6 +33,7 @@ IGNORED_HEADERS = {
     "date",
     "cache-control",
     "server",
+    "host",
     "location",  # Location-header is handled differently!
 }
 


### PR DESCRIPTION
Ignore host header, otherwise triggering a changed device from `SsdpListener`.

Fixes https://github.com/home-assistant/core/issues/72543, https://github.com/home-assistant/core/issues/72848 and https://github.com/home-assistant/core/issues/71689. 