### PR TITLE
DmrDevice helper method improvements

### DIFF
--- a/changes/142.bugfix
+++ b/changes/142.bugfix
@@ -1,0 +1,2 @@
+* `DmrDevice.async_wait_for_can_play` will poll for changes to the `CurrentTransportActions` state variable, instead of just waiting for events.
+* `DmrDevice._fetch_headers` will perform a GET with a Range for the first byte, to minimise unnecessary network traffic. (@chishm)

--- a/tests/fixtures/dlna/dmr/action_GetCurrentTransportActions_PlaySeek.xml
+++ b/tests/fixtures/dlna/dmr/action_GetCurrentTransportActions_PlaySeek.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope
+	s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+	xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body>
+		<u:GetCurrentTransportActionsResponse
+			xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+			<Actions>Play,Seek</Actions>
+		</u:GetCurrentTransportActionsResponse>
+	</s:Body>
+</s:Envelope>

--- a/tests/fixtures/dlna/dmr/action_GetCurrentTransportActions_Stop.xml
+++ b/tests/fixtures/dlna/dmr/action_GetCurrentTransportActions_Stop.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope
+	s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+	xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body>
+		<u:GetCurrentTransportActionsResponse
+			xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+			<Actions>Stop</Actions>
+		</u:GetCurrentTransportActionsResponse>
+	</s:Body>
+</s:Envelope>

--- a/tests/profiles/test_dlna_dmr.py
+++ b/tests/profiles/test_dlna_dmr.py
@@ -1,6 +1,7 @@
 """Unit tests for the DLNA DMR profile."""
 
 import asyncio
+import sys
 import time
 from typing import List, Sequence
 from unittest import mock
@@ -289,6 +290,7 @@ async def test_wait_for_can_play_timeout() -> None:
     assert not profile.can_play
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Need Python 3.8 for AsyncMock")
 @pytest.mark.asyncio
 async def test_fetch_headers() -> None:
     """Test _fetch_headers when the server supports HEAD, GET with range, or just GET."""

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -37,7 +37,8 @@ def test_fixed_host_header() -> None:
     assert _fixed_host_header("http://[fe80::1]:8000/root%desc") == {}
 
 
-def test_server_init() -> None:
+@pytest.mark.asyncio
+async def test_server_init() -> None:
     """Test initialization of an AiohttpNotifyServer."""
     requester = UpnpTestRequester(RESPONSE_MAP)
     server = AiohttpNotifyServer(requester, ("192.168.1.2", 8090))


### PR DESCRIPTION
Heya @StevenLooman, here's a few improvements for the `DmrDevice` profile. Mainly motivated by https://github.com/home-assistant/core/issues/70243, they may or may not fix that bug, but improve behaviour in any case.

First up is polling in the `DmrDevice.async_wait_for_can_play` method. Originally the method relied on the DMR device to send it an event with a change to the `CurrentTransportActions`, letting it know when the device could Play. I've added some polling in too, using the `GetCurrentTransportActions` action, to cover the cases where events might not work.

I've also modified `DmrDevice._fetch_headers` to try a GET with a Range of only 1 byte, to save on network traffic. I spotted this when looking at traffic debug logs, which would sometimes contain an entire media file when all it really wanted was the HTTP headers.

I don't think either of these changes warrant a new release immediately, and can wait until there's some more significant changes.