### PR TITLE
Fix indexing bug in cli parsing scope_id in IPv6 target

### DIFF
--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -347,7 +347,7 @@ def source_target(
 
     if source is not None and target is not None and ":" in target:
         if "%" in target:
-            idx = source.index("%")
+            idx = target.index("%")
             target_ip, scope_id = target[:idx], int(target[idx + 1 :])
         else:
             target_ip, scope_id = target, 0

--- a/changes/159.bugfix
+++ b/changes/159.bugfix
@@ -1,0 +1,1 @@
+Fix indexing bug in cli parsing scope_id in IPv6 target (@senarvi)


### PR DESCRIPTION
Fix indexing bug in cli parsing scope_id in IPv6 target