### PR TITLE
Reduce number of dict lookups for same_headers_differ

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -180,13 +180,14 @@ def same_headers_differ(
     current_headers: CaseInsensitiveDict, new_headers: CaseInsensitiveDict
 ) -> bool:
     """Compare headers present in both to see if anything interesting has changed."""
-    for header, current_value in current_headers.as_dict().items():
-        if header.startswith("_"):
+    current_headers_dict = current_headers.as_dict()
+    for lower_header, header in current_headers.case_map().items():
+        if len(lower_header) and lower_header[0] == "_":
             continue
-        lower_header = header.lower()
         if lower_header in IGNORED_HEADERS:
             continue
         new_value = new_headers.get_lower(lower_header)
+        current_value = current_headers_dict[header]
         if new_value is not None and current_value != new_value:
             _LOGGER.debug(
                 "Header %s changed from %s to %s", header, current_value, new_value

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -189,7 +189,7 @@ def same_headers_differ(
 
     for lower_header, current_header in current_headers_case_map.items():
         if (
-            len(lower_header) and lower_header[0] == "_"
+            lower_header != "" and lower_header[0] == "_"
         ) or lower_header in IGNORED_HEADERS:
             continue
         new_header = new_headers_case_map.get(lower_header, _SENTINEL)
@@ -204,7 +204,7 @@ def same_headers_differ(
                     new_value,
                 )
                 return True
-            
+
     return False
 
 

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -184,6 +184,10 @@ def same_headers_differ(
     current_headers_dict = current_headers.as_dict()
     new_headers_dict = new_headers.as_dict()
 
+    if current_headers_dict == new_headers_dict:
+        # Most common case, nothing changed.
+        return False
+
     new_headers_case_map = new_headers.case_map()
     current_headers_case_map = current_headers.case_map()
 
@@ -204,6 +208,7 @@ def same_headers_differ(
                     new_value,
                 )
                 return True
+            
     return False
 
 

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -8,7 +8,7 @@ from asyncio.events import AbstractEventLoop
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import ip_address
-from typing import Any, Callable, Coroutine, Dict, Mapping, Optional, Set, Tuple
+from typing import Any, Callable, Coroutine, Dict, Mapping, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
 
 from async_upnp_client.advertisement import SsdpAdvertisementListener
@@ -192,7 +192,9 @@ def same_headers_differ(
             lower_header != "" and lower_header[0] == "_"
         ) or lower_header in IGNORED_HEADERS:
             continue
-        new_header = new_headers_case_map.get(lower_header, _SENTINEL)
+        new_header: Union[str, object] = new_headers_case_map.get(
+            lower_header, _SENTINEL
+        )
         if new_header is not _SENTINEL:
             current_value = current_headers_dict[current_header]
             new_value = new_headers_dict[new_header]

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -192,9 +192,7 @@ def same_headers_differ(
             lower_header != "" and lower_header[0] == "_"
         ) or lower_header in IGNORED_HEADERS:
             continue
-        new_header: Union[str, object] = new_headers_case_map.get(
-            lower_header, _SENTINEL
-        )
+        new_header = new_headers_case_map.get(lower_header, _SENTINEL)  # type: ignore[index]
         if new_header is not _SENTINEL:
             current_value = current_headers_dict[current_header]
             new_value = new_headers_dict[new_header]

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -184,10 +184,6 @@ def same_headers_differ(
     current_headers_dict = current_headers.as_dict()
     new_headers_dict = new_headers.as_dict()
 
-    if current_headers_dict == new_headers_dict:
-        # Most common case, nothing changed.
-        return False
-
     new_headers_case_map = new_headers.case_map()
     current_headers_case_map = current_headers.case_map()
 

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -189,9 +189,8 @@ def same_headers_differ(
 
     for lower_header, current_header in current_headers_case_map.items():
         if (
-            (len(lower_header) and lower_header[0] == "_")
-            or lower_header in IGNORED_HEADERS
-        ):
+            len(lower_header) and lower_header[0] == "_"
+        ) or lower_header in IGNORED_HEADERS:
             continue
         new_header = new_headers_case_map.get(lower_header, _SENTINEL)
         if new_header is not _SENTINEL:

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -192,10 +192,10 @@ def same_headers_differ(
             lower_header != "" and lower_header[0] == "_"
         ) or lower_header in IGNORED_HEADERS:
             continue
-        new_header = new_headers_case_map.get(lower_header, _SENTINEL)  # type: ignore[index]
+        new_header = new_headers_case_map.get(lower_header, _SENTINEL)
         if new_header is not _SENTINEL:
             current_value = current_headers_dict[current_header]
-            new_value = new_headers_dict[new_header]
+            new_value = new_headers_dict[new_header]  # type: ignore[index]
             if current_value != new_value:
                 _LOGGER.debug(
                     "Header %s changed from %s to %s",

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -8,7 +8,7 @@ from asyncio.events import AbstractEventLoop
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import ip_address
-from typing import Any, Callable, Coroutine, Dict, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Callable, Coroutine, Dict, Mapping, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from async_upnp_client.advertisement import SsdpAdvertisementListener

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -182,7 +182,11 @@ def same_headers_differ(
     """Compare headers present in both to see if anything interesting has changed."""
     current_headers_dict = current_headers.as_dict()
     for lower_header, header in current_headers.case_map().items():
-        if len(lower_header) and lower_header[0] == "_" or lower_header in IGNORED_HEADERS:
+        if (
+            len(lower_header)
+            and lower_header[0] == "_"
+            or lower_header in IGNORED_HEADERS
+        ):
             continue
         new_value = new_headers.get_lower(lower_header)
         current_value = current_headers_dict[header]

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -182,9 +182,7 @@ def same_headers_differ(
     """Compare headers present in both to see if anything interesting has changed."""
     current_headers_dict = current_headers.as_dict()
     for lower_header, header in current_headers.case_map().items():
-        if len(lower_header) and lower_header[0] == "_":
-            continue
-        if lower_header in IGNORED_HEADERS:
+        if len(lower_header) and lower_header[0] == "_" or lower_header in IGNORED_HEADERS:
             continue
         new_value = new_headers.get_lower(lower_header)
         current_value = current_headers_dict[header]

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -189,8 +189,7 @@ def same_headers_differ(
 
     for lower_header, current_header in current_headers_case_map.items():
         if (
-            len(lower_header)
-            and lower_header[0] == "_"
+            (len(lower_header) and lower_header[0] == "_")
             or lower_header in IGNORED_HEADERS
         ):
             continue

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -18,6 +18,8 @@ from voluptuous import Invalid
 EXTERNAL_IP = "1.1.1.1"
 EXTERNAL_PORT = 80
 
+_SENTINEL = object()
+
 
 class CaseInsensitiveDict(abcMutableMapping):
     """Case insensitive dict."""
@@ -26,6 +28,10 @@ class CaseInsensitiveDict(abcMutableMapping):
         """Initialize."""
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
         self._case_map: Dict[str, Any] = {k.lower(): k for k in self._data}
+
+    def case_map(self) -> Dict[str, str]:
+        """Get the case map."""
+        return self._case_map
 
     def as_dict(self) -> Dict[str, Any]:
         """Return the underlying dict without iterating."""
@@ -37,8 +43,9 @@ class CaseInsensitiveDict(abcMutableMapping):
 
     def get_lower(self, lower_key: str) -> Any:
         """Get a lower case key."""
-        if lower_key in self._case_map:
-            return self._data[self._case_map[lower_key]]
+        data_key = self._case_map.get(lower_key, _SENTINEL)
+        if data_key is not _SENTINEL:
+            return self._data[data_key]
         return None
 
     def replace(self, new_data: abcMapping) -> None:


### PR DESCRIPTION
This is roughly a ~46% speed up

Before
![before_same_headers_differ](https://github.com/StevenLooman/async_upnp_client/assets/663432/e24c4959-f5ec-4f63-9507-f17bdfdef407)


After
![same_headers_differ_after](https://github.com/StevenLooman/async_upnp_client/assets/663432/b877c895-c476-4163-b661-7db37c0fd75f)


This gets async_upnp_client just about as efficient as zeroconf
<img width="1224" alt="Screenshot 2023-05-20 at 11 10 19 PM" src="https://github.com/StevenLooman/async_upnp_client/assets/663432/d1212a2e-346b-462b-9e8c-e2228441c11b">

