### PR TITLE
Support backwards compatible service/device types

### DIFF
--- a/async_upnp_client/server.py
+++ b/async_upnp_client/server.py
@@ -344,10 +344,10 @@ class SsdpSearchResponder:
                 self._send_responses_device_udn(remote_addr, device)
         elif matched_devices := self._matched_devices_by_type(search_target):
             for device in matched_devices:
-                self._send_responses_device_type(remote_addr, device, headers["st"])
+                self._send_responses_device_type(remote_addr, device, search_target)
         elif matched_services := self._matched_services_by_type(search_target):
             for service in matched_services:
-                self._send_responses_service(remote_addr, service, headers["st"])
+                self._send_responses_service(remote_addr, service, search_target)
 
         if self.options.get(SSDP_SEARCH_RESPONDER_OPTION_ALWAYS_REPLY_WITH_ROOT_DEVICE):
             self._send_response_rootdevice(remote_addr)


### PR DESCRIPTION
The UPnP Device Architecture specification states in section 1.3.2:

> Updated versions of device and service types are REQUIRED to be fully backward compatible with previous versions. Devices
> MUST respond to M-SEARCH requests for any supported version. For example, if a device implements “urn:schemas-upnporg:service:xyz:2”, it MUST respond to search requests for both that type and “urn:schemas-upnp-org:service:xyz:1”. The
> response MUST specify the same version as was contained in the search request.

This patch implements that backwards-compatibility in M-SEARCH responses