### PR TITLE
Avoid looking up the local address each packet

### DIFF
--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -232,14 +232,14 @@ class SsdpProtocol(DatagramProtocol):
 
     def connection_made(self, transport: BaseTransport) -> None:
         """Handle connection made."""
-        _LOGGER.debug(
-            "Connection made, transport: %s, socket: %s",
-            transport,
-            transport.get_extra_info("socket"),
-        )
         self.transport = cast(DatagramTransport, transport)
         sock: Optional[socket.socket] = transport.get_extra_info("socket")
         self.local_addr = sock.getsockname() if sock is not None else None
+        _LOGGER.debug(
+            "Connection made, transport: %s, socket: %s",
+            transport,
+            sock,
+        )
 
         if self.async_on_connect:
             coro = self.async_on_connect(self.transport)
@@ -276,6 +276,8 @@ class SsdpProtocol(DatagramProtocol):
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         """Handle connection lost."""
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
         assert self.transport
         sock: Optional[socket.socket] = self.transport.get_extra_info("socket")
         _LOGGER.debug(
@@ -288,16 +290,18 @@ class SsdpProtocol(DatagramProtocol):
     def send_ssdp_packet(self, packet: bytes, target: AddressTupleVXType) -> None:
         """Send a SSDP packet."""
         assert self.transport
-        sock: Optional[socket.socket] = self.transport.get_extra_info("socket")
-        _LOGGER.debug(
-            "Sending SSDP packet, transport: %s, socket: %s, target: %s",
-            self.transport,
-            sock,
-            target,
-        )
-        _LOGGER_TRAFFIC_SSDP.debug(
-            "Sending SSDP packet, target: %s, data: %s", target, packet
-        )
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            sock: Optional[socket.socket] = self.transport.get_extra_info("socket")
+            _LOGGER.debug(
+                "Sending SSDP packet, transport: %s, socket: %s, target: %s",
+                self.transport,
+                sock,
+                target,
+            )
+        if _LOGGER_TRAFFIC_SSDP.isEnabledFor(logging.DEBUG):
+            _LOGGER_TRAFFIC_SSDP.debug(
+                "Sending SSDP packet, target: %s, data: %s", target, packet
+            )
         self.transport.sendto(packet, target)
 
 


### PR DESCRIPTION
The local addr will never change, we can set it when we set the transport.

Guard some debug logging that was making function calls to format arguments that are usually thrown away since debug logging is not usually enabled