### PR TITLE
Avoid lower-casing already lowercased strings

### DIFF
--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -24,7 +24,7 @@ from async_upnp_client.const import (
     UniqueDeviceName,
 )
 from async_upnp_client.exceptions import UpnpError
-from async_upnp_client.utils import CaseInsensitiveDict
+from async_upnp_client.utils import CaseInsensitiveDict, lowerstr
 
 SSDP_PORT = 1900
 SSDP_IP_V4 = "239.255.255.250"
@@ -176,6 +176,16 @@ def _cached_header_parse(
     return parsed_headers, request_line, udn
 
 
+LOWER__TIMESTAMP = lowerstr("_timestamp")
+LOWER__HOST = lowerstr("_host")
+LOWER__PORT = lowerstr("_port")
+LOWER__LOCAL_ADDR = lowerstr("_local_addr")
+LOWER__REMOTE_ADDR = lowerstr("_remote_addr")
+LOWER__UDN = lowerstr("_udn")
+LOWER__LOCATION_ORIGINAL = lowerstr("_location_original")
+LOWER_LOCATION = lowerstr("location")
+
+
 def decode_ssdp_packet(
     data: bytes,
     local_addr: Optional[AddressTupleVXType],
@@ -185,20 +195,20 @@ def decode_ssdp_packet(
     parsed_headers, request_line, udn = _cached_header_parse(data)
     # own data
     extra: dict[str, Any] = {
-        "_timestamp": datetime.now(),
-        "_host": get_host_string(remote_addr),
-        "_port": remote_addr[1],
-        "_local_addr": local_addr,
-        "_remote_addr": remote_addr,
+        LOWER__TIMESTAMP: datetime.now(),
+        LOWER__HOST: get_host_string(remote_addr),
+        LOWER__PORT: remote_addr[1],
+        LOWER__LOCAL_ADDR: local_addr,
+        LOWER__REMOTE_ADDR: remote_addr,
     }
     if udn:
-        extra["_udn"] = udn
+        extra[LOWER__UDN] = udn
 
     # adjust some headers
     location = parsed_headers.get("location", "")
     if location.strip():
-        extra["_location_original"] = location
-        extra["location"] = get_adjusted_url(location, remote_addr)
+        extra[LOWER__LOCATION_ORIGINAL] = location
+        extra[LOWER_LOCATION] = get_adjusted_url(location, remote_addr)
 
     headers = CaseInsensitiveDict(parsed_headers, **extra)
     return request_line, headers

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -23,7 +23,7 @@ from async_upnp_client.const import (
 )
 from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.ssdp import SSDP_MX, determine_source_target, udn_from_headers
-from async_upnp_client.utils import CaseInsensitiveDict, CaseInsensitiveDictCopy
+from async_upnp_client.utils import CaseInsensitiveDict
 
 _SENTINEL = object()
 _LOGGER = logging.getLogger(__name__)

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -23,7 +23,7 @@ from async_upnp_client.const import (
 )
 from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.ssdp import SSDP_MX, determine_source_target, udn_from_headers
-from async_upnp_client.utils import CaseInsensitiveDict
+from async_upnp_client.utils import CaseInsensitiveDict, CaseInsensitiveDictCopy
 
 _SENTINEL = object()
 _LOGGER = logging.getLogger(__name__)
@@ -159,13 +159,11 @@ class SsdpDevice:
         search_headers = self.search_headers.get(device_or_service_type)
         advertisement_headers = self.advertisement_headers.get(device_or_service_type)
         if search_headers and advertisement_headers:
-            header_dict = CaseInsensitiveDict(
-                search_headers.as_dict(), **advertisement_headers.as_dict()
-            )
+            header_dict = search_headers.combine(advertisement_headers)
         elif search_headers:
-            header_dict = CaseInsensitiveDict(search_headers.as_dict())
+            header_dict = search_headers.copy()
         elif advertisement_headers:
-            header_dict = CaseInsensitiveDict(advertisement_headers.as_dict())
+            header_dict = advertisement_headers.copy()
         else:
             return CaseInsensitiveDict()
         del header_dict["_source"]

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -33,8 +33,8 @@ class CaseInsensitiveDict(abcMutableMapping):
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
         self._case_map = {
             k
-            if type(k) is lowerstr
-            else lowerstr(k.lower()): k  # pylint: disable=unidiomatic-typecheck
+            if type(k) is lowerstr # pylint: disable=unidiomatic-typecheck
+            else lowerstr(k.lower()): k  
             for k in self._data
         }
 
@@ -65,8 +65,8 @@ class CaseInsensitiveDict(abcMutableMapping):
             self._data = {**new_data}
         self._case_map = {
             k
-            if type(k) is lowerstr
-            else lowerstr(k.lower()): k  # pylint: disable=unidiomatic-typecheck
+            if type(k) is lowerstr # pylint: disable=unidiomatic-typecheck
+            else lowerstr(k.lower()): k  
             for k in self._data
         }
 

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -21,13 +21,19 @@ EXTERNAL_PORT = 80
 _SENTINEL = object()
 
 
+class lowerstr(str):
+    """A prelowered string."""
+
+
 class CaseInsensitiveDict(abcMutableMapping):
     """Case insensitive dict."""
 
     def __init__(self, data: Optional[abcMapping] = None, **kwargs: Any) -> None:
         """Initialize."""
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
-        self._case_map: Dict[str, Any] = {k.lower(): k for k in self._data}
+        self._case_map: Dict[str, Any] = {
+            k if type(k) is lowerstr else lowerstr(k.lower()): k for k in self._data
+        }
 
     def case_map(self) -> Dict[str, str]:
         """Get the case map."""
@@ -54,7 +60,9 @@ class CaseInsensitiveDict(abcMutableMapping):
             self._data = new_data.as_dict().copy()
         else:
             self._data = {**new_data}
-        self._case_map = {k.lower(): k for k in self._data}
+        self._case_map = {
+            k if type(k) is lowerstr else lowerstr(k.lower()): k for k in self._data
+        }
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set item."""

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -21,7 +21,7 @@ EXTERNAL_PORT = 80
 _SENTINEL = object()
 
 
-class lowerstr(str):
+class lowerstr(str):  # pylint: disable=invalid-name
     """A prelowered string."""
 
 
@@ -31,8 +31,11 @@ class CaseInsensitiveDict(abcMutableMapping):
     def __init__(self, data: Optional[abcMapping] = None, **kwargs: Any) -> None:
         """Initialize."""
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
-        self._case_map: Dict[str, Any] = {
-            k if type(k) is lowerstr else lowerstr(k.lower()): k for k in self._data
+        self._case_map = {
+            k
+            if type(k) is lowerstr
+            else lowerstr(k.lower()): k  # pylint: disable=unidiomatic-typecheck
+            for k in self._data
         }
 
     def case_map(self) -> Dict[str, str]:
@@ -61,7 +64,10 @@ class CaseInsensitiveDict(abcMutableMapping):
         else:
             self._data = {**new_data}
         self._case_map = {
-            k if type(k) is lowerstr else lowerstr(k.lower()): k for k in self._data
+            k
+            if type(k) is lowerstr
+            else lowerstr(k.lower()): k  # pylint: disable=unidiomatic-typecheck
+            for k in self._data
         }
 
     def __setitem__(self, key: str, value: Any) -> None:

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -33,8 +33,8 @@ class CaseInsensitiveDict(abcMutableMapping):
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
         self._case_map = {
             k
-            if type(k) is lowerstr # pylint: disable=unidiomatic-typecheck
-            else lowerstr(k.lower()): k  
+            if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
+            else lowerstr(k.lower()): k
             for k in self._data
         }
 
@@ -65,8 +65,8 @@ class CaseInsensitiveDict(abcMutableMapping):
             self._data = {**new_data}
         self._case_map = {
             k
-            if type(k) is lowerstr # pylint: disable=unidiomatic-typecheck
-            else lowerstr(k.lower()): k  
+            if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
+            else lowerstr(k.lower()): k
             for k in self._data
         }
 

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -38,6 +38,27 @@ class CaseInsensitiveDict(abcMutableMapping):
             for k in self._data
         }
 
+    def copy(self) -> "CaseInsensitiveDict":
+        """Copy a CaseInsensitiveDict.
+
+        Returns a copy of CaseInsensitiveDict.
+        """
+        _copy = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
+        _copy._data = self._data.copy()
+        _copy._case_map = self._case_map.copy()
+        return _copy
+
+    def combine(self, other: "CaseInsensitiveDict") -> "CaseInsensitiveDict":
+        """Combine a CaseInsensitiveDict with another CaseInsensitiveDict.
+
+        Returns a brand new CaseInsensitiveDict that is the combination
+        of the two CaseInsensitiveDicts.
+        """
+        _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
+        _combined._data = {**self._data.copy(), **other._data.copy()}
+        _combined._case_map = {**self._case_map.copy(), **other._case_map.copy()}
+        return _combined
+
     def case_map(self) -> Dict[str, str]:
         """Get the case map."""
         return self._case_map

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -34,7 +34,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         self._case_map = {
             k
             if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
-            else lowerstr(k.lower()): k
+            else k.lower(): k
             for k in self._data
         }
 
@@ -61,14 +61,15 @@ class CaseInsensitiveDict(abcMutableMapping):
         """Replace the underlying dict."""
         if isinstance(new_data, CaseInsensitiveDict):
             self._data = new_data.as_dict().copy()
+            self._case_map = new_data.case_map().copy()
         else:
             self._data = {**new_data}
-        self._case_map = {
-            k
-            if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
-            else lowerstr(k.lower()): k
-            for k in self._data
-        }
+            self._case_map = {
+                k
+                if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
+                else k.lower(): k
+                for k in self._data
+            }
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Set item."""

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -31,7 +31,7 @@ class CaseInsensitiveDict(abcMutableMapping):
     def __init__(self, data: Optional[abcMapping] = None, **kwargs: Any) -> None:
         """Initialize."""
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
-        self._case_map: Dict[str, Any]  = {
+        self._case_map: Dict[str, Any] = {
             k
             if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
             else k.lower(): k

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -31,7 +31,7 @@ class CaseInsensitiveDict(abcMutableMapping):
     def __init__(self, data: Optional[abcMapping] = None, **kwargs: Any) -> None:
         """Initialize."""
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
-        self._case_map = {
+        self._case_map: Dict[str, str]  = {
             k
             if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
             else k.lower(): k

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -43,6 +43,7 @@ class CaseInsensitiveDict(abcMutableMapping):
 
         Returns a copy of CaseInsensitiveDict.
         """
+        # pylint: disable=protected-access
         _copy = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
         _copy._data = self._data.copy()
         _copy._case_map = self._case_map.copy()
@@ -54,6 +55,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         Returns a brand new CaseInsensitiveDict that is the combination
         of the two CaseInsensitiveDicts.
         """
+        # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
         _combined._data = {**self._data.copy(), **other._data.copy()}
         _combined._case_map = {**self._case_map.copy(), **other._case_map.copy()}

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -31,7 +31,7 @@ class CaseInsensitiveDict(abcMutableMapping):
     def __init__(self, data: Optional[abcMapping] = None, **kwargs: Any) -> None:
         """Initialize."""
         self._data: Dict[str, Any] = {**(data or {}), **kwargs}
-        self._case_map: Dict[str, str]  = {
+        self._case_map: Dict[str, Any]  = {
             k
             if type(k) is lowerstr  # pylint: disable=unidiomatic-typecheck
             else k.lower(): k


### PR DESCRIPTION
- Use the upstr concept (in our case lowerstr) from multidict https://aiohttp-kxepal-test.readthedocs.io/en/latest/multidict.html#upstr
- Add `copy` and `combine` methods to the `CaseInsensitiveDict` to avoid reconstructing them over and over again

This speeds up `combined_headers` and reduces calls to `.lower()` by ~12000 per minute on my production network