### PR TITLE
Avoid fetching time many times to purge devices

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -15,7 +15,6 @@ from typing import (
     Dict,
     Mapping,
     Optional,
-    Set,
     Tuple,
     KeysView,
 )

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -142,9 +142,10 @@ class SsdpDevice:
         self.purge_locations()
         return set(self._locations.keys())
 
-    def purge_locations(self) -> None:
+    def purge_locations(self, now: Optional[datetime] = None) -> None:
         """Purge locations which are no longer valid/timed out."""
-        now = datetime.now()
+        if not now:
+            now = datetime.now()
         to_remove = [
             location for location, valid_to in self._locations.items() if now > valid_to
         ]
@@ -465,7 +466,7 @@ class SsdpDeviceTracker:
                 to_remove.append(usn)
             elif not self.next_valid_to or device.valid_to < self.next_valid_to:
                 self.next_valid_to = device.valid_to
-                device.purge_locations()
+                device.purge_locations(now)
         for usn in to_remove:
             _LOGGER.debug("Purging device, USN: %s", usn)
             del self.devices[usn]

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -475,9 +475,7 @@ async def test_purge_devices_2() -> None:
     async_callback.reset_mock()
     udn2 = "uuid:device_2"
     with patch("async_upnp_client.ssdp_listener.datetime") as datetime_mock:
-        new_timestamp = SEARCH_HEADERS_DEFAULT[
-            "_timestamp"
-        ] + timedelta(hours=1)
+        new_timestamp = SEARCH_HEADERS_DEFAULT["_timestamp"] + timedelta(hours=1)
         device_2_headers = CaseInsensitiveDict(
             {
                 **SEARCH_HEADERS_DEFAULT,

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -478,8 +478,7 @@ async def test_purge_devices_2() -> None:
     device_2_headers = CaseInsensitiveDict(
         {
             **SEARCH_HEADERS_DEFAULT,
-            "USN": udn2
-            + "::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
+            "USN": udn2 + "::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
             "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
             "_udn": udn2,
             "_timestamp": new_timestamp,

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -475,9 +475,10 @@ async def test_purge_devices_2() -> None:
     async_callback.reset_mock()
     udn2 = "uuid:device_2"
     with patch("async_upnp_client.ssdp_listener.datetime") as datetime_mock:
-        datetime_mock.now.return_value = SEARCH_HEADERS_DEFAULT[
+        new_timestamp = SEARCH_HEADERS_DEFAULT[
             "_timestamp"
         ] + timedelta(hours=1)
+        datetime_mock.now.return_value = new_timestamp
         device_2_headers = CaseInsensitiveDict(
             {
                 **SEARCH_HEADERS_DEFAULT,
@@ -485,6 +486,7 @@ async def test_purge_devices_2() -> None:
                 + "::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
                 "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
                 "_udn": udn2,
+                "_timestamp": new_timestamp,
             }
         )
         await see_search(listener, SEARCH_REQUEST_LINE, device_2_headers)

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -478,7 +478,6 @@ async def test_purge_devices_2() -> None:
         new_timestamp = SEARCH_HEADERS_DEFAULT[
             "_timestamp"
         ] + timedelta(hours=1)
-        datetime_mock.now.return_value = new_timestamp
         device_2_headers = CaseInsensitiveDict(
             {
                 **SEARCH_HEADERS_DEFAULT,

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -474,19 +474,18 @@ async def test_purge_devices_2() -> None:
     # See anotherdevice through search.
     async_callback.reset_mock()
     udn2 = "uuid:device_2"
-    with patch("async_upnp_client.ssdp_listener.datetime") as datetime_mock:
-        new_timestamp = SEARCH_HEADERS_DEFAULT["_timestamp"] + timedelta(hours=1)
-        device_2_headers = CaseInsensitiveDict(
-            {
-                **SEARCH_HEADERS_DEFAULT,
-                "USN": udn2
-                + "::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
-                "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
-                "_udn": udn2,
-                "_timestamp": new_timestamp,
-            }
-        )
-        await see_search(listener, SEARCH_REQUEST_LINE, device_2_headers)
+    new_timestamp = SEARCH_HEADERS_DEFAULT["_timestamp"] + timedelta(hours=1)
+    device_2_headers = CaseInsensitiveDict(
+        {
+            **SEARCH_HEADERS_DEFAULT,
+            "USN": udn2
+            + "::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
+            "ST": "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",
+            "_udn": udn2,
+            "_timestamp": new_timestamp,
+        }
+    )
+    await see_search(listener, SEARCH_REQUEST_LINE, device_2_headers)
     async_callback.assert_awaited_once_with(
         ANY,
         "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:2",


### PR DESCRIPTION
Calling `SsdpDevice.locations` is now a `KeysView` and no longer has the side effect of purging stale locations

We now use the `_timestamp` that was injected into the headers to avoid fetching time again.

AFAICT `.locations` is only called in ssdp_listener so its unlikely this change has an external effect, and since we always call `self.purge_devices` in `_see_device` it likely is backwards compatible.

If we call `.locations` outside of that path its a breaking change