### PR TITLE
Cache more of the SSDP packet decode

### DIFF
--- a/async_upnp_client/description_cache.py
+++ b/async_upnp_client/description_cache.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import logging
-from typing import Any, Mapping, Optional, Tuple, Union, cast
+from typing import Any, Dict, Mapping, Optional, Tuple, Union, cast
 
 import aiohttp
 import defusedxml.ElementTree as DET
@@ -42,7 +42,7 @@ class DescriptionCache:
     def __init__(self, requester: UpnpRequester):
         """Initialize."""
         self._requester = requester
-        self._cache_dict: dict[str, Union[asyncio.Event, DescriptionType]] = {}
+        self._cache_dict: Dict[str, Union[asyncio.Event, DescriptionType]] = {}
 
     async def async_get_description_xml(self, location: str) -> Optional[str]:
         """Get a description as XML, either from cache or download it."""

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -9,7 +9,17 @@ from asyncio.events import AbstractEventLoop
 from datetime import datetime
 from functools import lru_cache
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 from urllib.parse import urlsplit, urlunsplit
 
 from aiohttp.http_exceptions import InvalidHeader
@@ -197,7 +207,7 @@ def _cached_decode_ssdp_packet(
     """Cache decoding SSDP packets."""
     parsed_headers, request_line, udn = _cached_header_parse(data)
     # own data
-    extra: dict[str, Any] = {LOWER__HOST: get_host_string(remote_addr_without_port)}
+    extra: Dict[str, Any] = {LOWER__HOST: get_host_string(remote_addr_without_port)}
     if udn:
         extra[LOWER__UDN] = udn
 

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -9,16 +9,16 @@ from asyncio.events import AbstractEventLoop
 from datetime import datetime
 from functools import lru_cache
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Any, Callable, Coroutine, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional, Tuple, Union, cast
 from urllib.parse import urlsplit, urlunsplit
-from typing import TYPE_CHECKING
+
 from aiohttp.http_exceptions import InvalidHeader
 from aiohttp.http_parser import HeadersParser
 from multidict import CIMultiDictProxy
 
 from async_upnp_client.const import (
-    AddressTupleV6Type,
     AddressTupleV4Type,
+    AddressTupleV6Type,
     AddressTupleVXType,
     IPvXAddress,
     SsdpHeaders,
@@ -224,7 +224,7 @@ def decode_ssdp_packet(
         if TYPE_CHECKING:
             remote_addr = cast(AddressTupleV6Type, remote_addr)
         addr, port, flow, scope = remote_addr
-        remote_addr_without_port = addr, 0, flow, scope
+        remote_addr_without_port: AddressTupleVXType = addr, 0, flow, scope
     else:
         if TYPE_CHECKING:
             remote_addr = cast(AddressTupleV4Type, remote_addr)

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -231,15 +231,13 @@ def decode_ssdp_packet(
         addr, port = remote_addr
         remote_addr_without_port = remote_addr[0], 0
     request_line, headers = _cached_decode_ssdp_packet(data, remote_addr_without_port)
-    return request_line, headers.combine(
-        CaseInsensitiveDict(
-            {
-                LOWER__TIMESTAMP: datetime.now(),
-                LOWER__REMOTE_ADDR: remote_addr,
-                LOWER__PORT: port,
-                LOWER__LOCAL_ADDR: local_addr,
-            }
-        )
+    return request_line, headers.combine_lower_dict(
+        {
+            LOWER__TIMESTAMP: datetime.now(),
+            LOWER__REMOTE_ADDR: remote_addr,
+            LOWER__PORT: port,
+            LOWER__LOCAL_ADDR: local_addr,
+        }
     )
 
 

--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -11,13 +11,14 @@ from functools import lru_cache
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import Any, Callable, Coroutine, Optional, Tuple, Union, cast
 from urllib.parse import urlsplit, urlunsplit
-
+from typing import TYPE_CHECKING
 from aiohttp.http_exceptions import InvalidHeader
 from aiohttp.http_parser import HeadersParser
 from multidict import CIMultiDictProxy
 
 from async_upnp_client.const import (
     AddressTupleV6Type,
+    AddressTupleV4Type,
     AddressTupleVXType,
     IPvXAddress,
     SsdpHeaders,
@@ -53,7 +54,8 @@ _LOGGER_TRAFFIC_SSDP = logging.getLogger("async_upnp_client.traffic.ssdp")
 def get_host_string(addr: AddressTupleVXType) -> str:
     """Construct host string from address tuple."""
     if len(addr) == 4:
-        addr = cast(AddressTupleV6Type, addr)
+        if TYPE_CHECKING:
+            addr = cast(AddressTupleV6Type, addr)
         if addr[3]:
             return f"{addr[0]}%{addr[3]}"
 
@@ -74,7 +76,8 @@ def get_adjusted_url(url: str, addr: AddressTupleVXType) -> str:
     if len(addr) < 4:
         return url
 
-    addr = cast(AddressTupleV6Type, addr)
+    if TYPE_CHECKING:
+        addr = cast(AddressTupleV6Type, addr)
 
     if not addr[3]:
         return url
@@ -150,7 +153,7 @@ def udn_from_headers(
     return None
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=128)
 def _cached_header_parse(
     data: bytes,
 ) -> Tuple[CIMultiDictProxy[str], str, Optional[UniqueDeviceName]]:
@@ -186,21 +189,15 @@ LOWER__LOCATION_ORIGINAL = lowerstr("_location_original")
 LOWER_LOCATION = lowerstr("location")
 
 
-def decode_ssdp_packet(
+@lru_cache(maxsize=512)
+def _cached_decode_ssdp_packet(
     data: bytes,
-    local_addr: Optional[AddressTupleVXType],
-    remote_addr: AddressTupleVXType,
+    remote_addr_without_port: AddressTupleVXType,
 ) -> Tuple[str, CaseInsensitiveDict]:
-    """Decode a message."""
+    """Cache decoding SSDP packets."""
     parsed_headers, request_line, udn = _cached_header_parse(data)
     # own data
-    extra: dict[str, Any] = {
-        LOWER__TIMESTAMP: datetime.now(),
-        LOWER__HOST: get_host_string(remote_addr),
-        LOWER__PORT: remote_addr[1],
-        LOWER__LOCAL_ADDR: local_addr,
-        LOWER__REMOTE_ADDR: remote_addr,
-    }
+    extra: dict[str, Any] = {LOWER__HOST: get_host_string(remote_addr_without_port)}
     if udn:
         extra[LOWER__UDN] = udn
 
@@ -208,10 +205,42 @@ def decode_ssdp_packet(
     location = parsed_headers.get("location", "")
     if location.strip():
         extra[LOWER__LOCATION_ORIGINAL] = location
-        extra[LOWER_LOCATION] = get_adjusted_url(location, remote_addr)
+        extra[LOWER_LOCATION] = get_adjusted_url(location, remote_addr_without_port)
 
     headers = CaseInsensitiveDict(parsed_headers, **extra)
     return request_line, headers
+
+
+def decode_ssdp_packet(
+    data: bytes,
+    local_addr: Optional[AddressTupleVXType],
+    remote_addr: AddressTupleVXType,
+) -> Tuple[str, CaseInsensitiveDict]:
+    """Decode a message."""
+    # We want to use remote_addr_without_port as the cache
+    # key since nothing in _cached_decode_ssdp_packet cares
+    # about the port
+    if len(remote_addr) == 4:
+        if TYPE_CHECKING:
+            remote_addr = cast(AddressTupleV6Type, remote_addr)
+        addr, port, flow, scope = remote_addr
+        remote_addr_without_port = addr, 0, flow, scope
+    else:
+        if TYPE_CHECKING:
+            remote_addr = cast(AddressTupleV4Type, remote_addr)
+        addr, port = remote_addr
+        remote_addr_without_port = remote_addr[0], 0
+    request_line, headers = _cached_decode_ssdp_packet(data, remote_addr_without_port)
+    return request_line, headers.combine(
+        CaseInsensitiveDict(
+            {
+                LOWER__TIMESTAMP: datetime.now(),
+                LOWER__REMOTE_ADDR: remote_addr,
+                LOWER__PORT: port,
+                LOWER__LOCAL_ADDR: local_addr,
+            }
+        )
+    )
 
 
 class SsdpProtocol(DatagramProtocol):

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -71,6 +71,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         Returns a brand new CaseInsensitiveDict that is the combination
         of the CaseInsensitiveDict and dict where all the keys are lowerstr.
         """
+        # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
         _combined._data = {**self._data, **lower_dict}  # type: ignore[arg-type]
         _combined._case_map = {**self._case_map, **{k: k for k in lower_dict}}

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -64,7 +64,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         return _combined
 
     def combine_lower_dict(self, lower_dict: dict[lowerstr, Any]) -> None:
-        """ "Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
+        """Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
 
         Returns a brand new CaseInsensitiveDict that is the combination
         of the CaseInsensitiveDict and dict where all the keys are lowerstr.

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -71,7 +71,6 @@ class CaseInsensitiveDict(abcMutableMapping):
         Returns a brand new CaseInsensitiveDict that is the combination
         of the CaseInsensitiveDict and dict where all the keys are lowerstr.
         """
-        # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
         _combined._data = {**self._data, **lower_dict}  # type: ignore[arg-type]
         _combined._case_map = {**self._case_map, **{k: k for k in lower_dict}}

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -63,7 +63,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         _combined._case_map = {**self._case_map, **other._case_map}
         return _combined
 
-    def combine_lower_dict(self, lower_dict: dict[lowerstr, Any]) -> None:
+    def combine_lower_dict(self, lower_dict: dict[lowerstr, Any]) -> "CaseInsensitiveDict":
         """Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
 
         Returns a brand new CaseInsensitiveDict that is the combination
@@ -71,7 +71,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         """
         # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
-        _combined._data = {**self._data, **lower_dict}
+        _combined._data = {**self._data, **lower_dict} # type: ignore[arg-type]
         _combined._case_map = {**self._case_map, **{k: k for k in lower_dict}}
         return _combined
 

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -64,7 +64,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         return _combined
 
     def combine_lower_dict(
-        self, lower_dict: dict[lowerstr, Any]
+        self, lower_dict: Dict[lowerstr, Any]
     ) -> "CaseInsensitiveDict":
         """Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
 

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -59,8 +59,20 @@ class CaseInsensitiveDict(abcMutableMapping):
         """
         # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
-        _combined._data = {**self._data.copy(), **other._data.copy()}
-        _combined._case_map = {**self._case_map.copy(), **other._case_map.copy()}
+        _combined._data = {**self._data, **other._data}
+        _combined._case_map = {**self._case_map, **other._case_map}
+        return _combined
+    
+    def combine_lower_dict(self, lower_dict: dict[lowerstr, Any]) -> None:
+        """"Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
+        
+        Returns a brand new CaseInsensitiveDict that is the combination
+        of the CaseInsensitiveDict and dict where all the keys are lowerstr.        
+        """
+        # pylint: disable=protected-access
+        _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
+        _combined._data = {**self._data, **lower_dict}
+        _combined._case_map = {**self._case_map, **{k: k for k in lower_dict}}
         return _combined
 
     def case_map(self) -> Dict[str, str]:

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -63,7 +63,9 @@ class CaseInsensitiveDict(abcMutableMapping):
         _combined._case_map = {**self._case_map, **other._case_map}
         return _combined
 
-    def combine_lower_dict(self, lower_dict: dict[lowerstr, Any]) -> "CaseInsensitiveDict":
+    def combine_lower_dict(
+        self, lower_dict: dict[lowerstr, Any]
+    ) -> "CaseInsensitiveDict":
         """Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
 
         Returns a brand new CaseInsensitiveDict that is the combination
@@ -71,7 +73,7 @@ class CaseInsensitiveDict(abcMutableMapping):
         """
         # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)
-        _combined._data = {**self._data, **lower_dict} # type: ignore[arg-type]
+        _combined._data = {**self._data, **lower_dict}  # type: ignore[arg-type]
         _combined._case_map = {**self._case_map, **{k: k for k in lower_dict}}
         return _combined
 

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -62,12 +62,12 @@ class CaseInsensitiveDict(abcMutableMapping):
         _combined._data = {**self._data, **other._data}
         _combined._case_map = {**self._case_map, **other._case_map}
         return _combined
-    
+
     def combine_lower_dict(self, lower_dict: dict[lowerstr, Any]) -> None:
-        """"Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
-        
+        """ "Combine a CaseInsensitiveDict with a dict where all the keys are lowerstr.
+
         Returns a brand new CaseInsensitiveDict that is the combination
-        of the CaseInsensitiveDict and dict where all the keys are lowerstr.        
+        of the CaseInsensitiveDict and dict where all the keys are lowerstr.
         """
         # pylint: disable=protected-access
         _combined = CaseInsensitiveDict.__new__(CaseInsensitiveDict)


### PR DESCRIPTION
Since we tend to listen on multiple interfaces we end up processing a lot of the same data. We can cache more of it. The hit rate is quite good

`2023-09-06 15:28:57.127 WARNING (MainThread) [async_upnp_client.ssdp] _cached_decode_ssdp_packet: CacheInfo(hits=2151, misses=455, maxsize=512, currsize=455)`