### PR TITLE
Reduce overhead to get_lower on CaseInsensitiveDict

### DIFF
--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -77,10 +77,7 @@ class CaseInsensitiveDict(abcMutableMapping):
 
     def get_lower(self, lower_key: str, default: Any = None) -> Any:
         """Get a lower case key."""
-        data_key = self._case_map.get(lower_key, _SENTINEL)
-        if data_key is not _SENTINEL:
-            return self._data.get(data_key, default)
-        return default
+        return self._data.get(self._case_map.get(lower_key, _SENTINEL), default)
 
     def replace(self, new_data: abcMapping) -> None:
         """Replace the underlying dict."""


### PR DESCRIPTION
This is much faster on the hit path, and tiny bit slower on the miss path. We have way more hits than misses so its a nice improvement