### PR TITLE
Avoid copy when calling replace on CaseInsensitiveDict

### DIFF
--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -83,10 +83,10 @@ class CaseInsensitiveDict(abcMutableMapping):
         return default
 
     def replace(self, new_data: abcMapping) -> None:
-        """Replace the underlying dict."""
+        """Replace the underlying dict without making a copy if possible."""
         if isinstance(new_data, CaseInsensitiveDict):
-            self._data = new_data.as_dict().copy()
-            self._case_map = new_data.case_map().copy()
+            self._data = new_data.as_dict()
+            self._case_map = new_data.case_map()
         else:
             self._data = {**new_data}
             self._case_map = {


### PR DESCRIPTION
Since the incoming `decode_ssdp_packet` is always creating a new `CaseInsensitiveDict` we can avoid a copy here and reduce memory churn

```
.loader: _load_stat
.format: SetFormat
.timemade: 1694178621.686545
.count: 28027
.size: 5360911
.kindname: 
.kindheader: Referrers by Kind (class / dict of class)
.numrows: 768
.r: 8 2097608 builtins.managedbuffer, dict of asyncio.sslproto.SSLProtocol
.r: 8679 748169 list
.r: 4513 400157 dict (no owner)
.r: 1572 191091 tuple
.r: 655 83539 homeassistant.core.State
.r: 106 71280 async_upnp_client.utils.CaseInsensitiveDict
```

This helps a lot. It was in the number 3 slot before