### PR TITLE
Cache SSDP packet validation

### DIFF
--- a/async_upnp_client/ssdp.py
+++ b/async_upnp_client/ssdp.py
@@ -138,6 +138,7 @@ def build_ssdp_search_packet(
     return build_ssdp_packet(request_line, headers)
 
 
+@lru_cache(maxsize=128)
 def is_valid_ssdp_packet(data: bytes) -> bool:
     """Check if data is a valid and decodable packet."""
     return (


### PR DESCRIPTION
Cache stats for lru_cache <function is_valid_ssdp_packet at 0x7fad1bce3b00> at /usr/local/lib/python3.11/site-packages/async_upnp_client/ssdp.py: CacheInfo(hits=10078, misses=2770, maxsize=128, currsize=128)