### PR TITLE
Improve performance of aiohttp calls

### DIFF
--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -9,7 +9,6 @@ from typing import Dict, Mapping, Optional, Tuple
 from urllib.parse import urlparse
 
 import aiohttp.web
-import async_timeout
 from aiohttp import (
     ClientConnectionError,
     ClientError,


### PR DESCRIPTION
- Avoid expensive debug formatting when not enabled
- Use built-in timeouts with ClientSession.request instead of async_timeout