### PR TITLE
Add a cache to split_commas

### DIFF
--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -225,6 +225,12 @@ def split_commas(input_: str) -> List[str]:
     return [item for item in stripped if item]
 
 
+@lru_cache(maxsize=128)
+def _lower_split_commas(input_: str) -> Set[str]:
+    """Lowercase version of split_commas."""
+    return {a.lower() for a in split_commas(input_)}
+
+
 class ConnectionManagerMixin(UpnpProfileDevice):
     """Mix-in to support ConnectionManager actions and state variables."""
 
@@ -427,18 +433,15 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         return state_var.value is not None or state_var.updated_at is not None
 
     @property
-    def _current_transport_actions(self) -> List[str]:
+    def _current_transport_actions(self) -> Set[str]:
         state_var = self._state_variable("AVT", "CurrentTransportActions")
         if not state_var:
-            return []
-        transport_actions = split_commas(state_var.value or "")
-        return [a.lower() for a in transport_actions]
+            return set()
+        return _lower_split_commas(state_var.value or "")
 
     def _can_transport_action(self, action: str) -> bool:
-        return (
-            action in self._current_transport_actions
-            or not self._has_current_transport_actions
-        )
+        current_transport_actions = self._current_transport_actions
+        return not current_transport_actions or action in current_transport_actions
 
     def _supports(self, var_name: str) -> bool:
         return (

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum, IntFlag
+from functools import lru_cache
 from http import HTTPStatus
 from mimetypes import guess_type
 from time import monotonic as monotonic_timer
@@ -213,6 +214,7 @@ def dlna_handle_notify_last_change(state_var: UpnpStateVariable) -> None:
     service.notify_changed_state_variables(changes_0)
 
 
+@lru_cache(maxsize=128)
 def split_commas(input_: str) -> List[str]:
     """
     Split a string into a list of comma separated values.

--- a/async_upnp_client/server.py
+++ b/async_upnp_client/server.py
@@ -649,7 +649,9 @@ class SsdpSearchResponder:
 
     def _build_response_rootdevice(self) -> bytes:
         """Send root device response."""
-        return self._build_response("upnp:rootdevice", f"{self.device.udn}::upnp:rootdevice")
+        return self._build_response(
+            "upnp:rootdevice", f"{self.device.udn}::upnp:rootdevice"
+        )
 
     def _build_responses_device_udn(self, device: UpnpDevice) -> bytes:
         """Send device responses for UDN."""


### PR DESCRIPTION
2023-09-25 18:26:20.809 CRITICAL (SyncWorker_14) [homeassistant.components.profiler] Cache stats for lru_cache <function split_commas at 0x7f25b2d5d6c0> at /usr/local/lib/python3.11/site-packages/async_upnp_client/profiles/dlna.py: CacheInfo(hits=1532, misses=2, maxsize=128, currsize=2)
