### PR TITLE
Only calculate client min/max/valid once

### DIFF
--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """async_upnp_client.client module."""
 
+# pylint: disable=too-many-lines
+
 import logging
 import urllib.parse
 from abc import ABC
@@ -816,6 +818,8 @@ def _parse_fault(
 
 T = TypeVar("T")  # pylint: disable=invalid-name
 
+_UNDEFINED = object()
+
 
 class UpnpStateVariable(Generic[T]):
     """Representation of a State Variable."""
@@ -835,19 +839,12 @@ class UpnpStateVariable(Generic[T]):
         self._value: Optional[Any] = None  # None, T or UPNP_VALUE_ERROR
         self._updated_at: Optional[datetime] = None
 
-        type_info = state_variable_info.type_info
-        allowed_values = type_info.allowed_values or []
-        self._min_value: Optional[T] = None
-        self._max_value: Optional[T] = None
-        self._allowed_values = {
-            self.coerce_python(allowed_value) for allowed_value in allowed_values
-        }
-        max_ = type_info.allowed_value_range.get("max")
-        if max_ is not None:
-            self._max_value = self.coerce_python(max_)
-        min_ = type_info.allowed_value_range.get("min")
-        if min_ is not None:
-            self._min_value = self.coerce_python(min_)
+        # When py3.12 is the minimum version, we can switch
+        # these to be @cached_property
+        self._min_value: Optional[T] = _UNDEFINED  # type: ignore[assignment]
+        self._max_value: Optional[T] = _UNDEFINED  # type: ignore[assignment]
+        self._allowed_values: Set[T] = _UNDEFINED  # type: ignore[assignment]
+        self._normalized_allowed_values: Set[T] = _UNDEFINED  # type: ignore[assignment]
 
     @property
     def service(self) -> UpnpService:
@@ -880,17 +877,43 @@ class UpnpStateVariable(Generic[T]):
     @property
     def min_value(self) -> Optional[T]:
         """Min value for this UpnpStateVariable, if defined."""
+        if self._min_value is _UNDEFINED:
+            min_ = self._state_variable_info.type_info.allowed_value_range.get("min")
+            if min_ is not None:
+                self._min_value = self.coerce_python(min_)
+            else:
+                self._min_value = None
         return self._min_value
 
     @property
     def max_value(self) -> Optional[T]:
         """Max value for this UpnpStateVariable, if defined."""
+        if self._max_value is _UNDEFINED:
+            max_ = self._state_variable_info.type_info.allowed_value_range.get("max")
+            if max_ is not None:
+                self._max_value = self.coerce_python(max_)
+            else:
+                self._max_value = None
         return self._max_value
 
     @property
     def allowed_values(self) -> Set[T]:
         """Set with allowed values for this UpnpStateVariable, if defined."""
+        if self._allowed_values is _UNDEFINED:
+            allowed_values = self._state_variable_info.type_info.allowed_values or []
+            self._allowed_values = {
+                self.coerce_python(allowed_value) for allowed_value in allowed_values
+            }
         return self._allowed_values
+
+    @property
+    def normalized_allowed_values(self) -> Set[T]:
+        """Set with normalized allowed values for this UpnpStateVariable, if defined."""
+        if self._normalized_allowed_values is _UNDEFINED:
+            self._normalized_allowed_values = {
+                allowed_value.lower().strip() for allowed_value in self.allowed_values
+            }
+        return self._normalized_allowed_values
 
     @property
     def send_events(self) -> bool:

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -907,11 +907,12 @@ class UpnpStateVariable(Generic[T]):
         return self._allowed_values
 
     @property
-    def normalized_allowed_values(self) -> Set[T]:
+    def normalized_allowed_values(self) -> Set[str]:
         """Set with normalized allowed values for this UpnpStateVariable, if defined."""
         if self._normalized_allowed_values is _UNDEFINED:
             self._normalized_allowed_values = {
-                allowed_value.lower().strip() for allowed_value in self.allowed_values
+                str(allowed_value).lower().strip()
+                for allowed_value in self.allowed_values
             }
         return self._normalized_allowed_values
 

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -844,7 +844,7 @@ class UpnpStateVariable(Generic[T]):
         self._min_value: Optional[T] = _UNDEFINED  # type: ignore[assignment]
         self._max_value: Optional[T] = _UNDEFINED  # type: ignore[assignment]
         self._allowed_values: Set[T] = _UNDEFINED  # type: ignore[assignment]
-        self._normalized_allowed_values: Set[T] = _UNDEFINED  # type: ignore[assignment]
+        self._normalized_allowed_values: Set[str] = _UNDEFINED  # type: ignore[assignment]
 
     @property
     def service(self) -> UpnpService:

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -1030,7 +1030,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
 
         for normalized_allowed_value in state_var.normalized_allowed_values:
             try:
-                mode = PlayMode[normalized_allowed_value]
+                mode = PlayMode[normalized_allowed_value.upper()]
             except KeyError:
                 # Unknown mode, don't report it as valid
                 continue

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -729,9 +729,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         state_var = self._state_variable("AVT", "A_ARG_TYPE_SeekMode")
         if action is None or state_var is None:
             return False
-
-        seek_modes = [mode.lower().strip() for mode in state_var.allowed_values]
-        return mode.lower() in seek_modes
+        return mode.lower() in state_var.normalized_allowed_values
 
     @property
     def has_seek_abs_time(self) -> bool:
@@ -1030,9 +1028,9 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         if state_var is None:
             return play_modes
 
-        for allowed_value in state_var.allowed_values:
+        for normalized_allowed_value in state_var.normalized_allowed_values:
             try:
-                mode = PlayMode[allowed_value.strip().upper()]
+                mode = PlayMode[normalized_allowed_value]
             except KeyError:
                 # Unknown mode, don't report it as valid
                 continue

--- a/tests/test_upnp_client.py
+++ b/tests/test_upnp_client.py
@@ -228,7 +228,7 @@ class TestUpnpStateVariable:
         service = device.service("urn:schemas-upnp-org:service:RenderingControl:1")
         state_var = service.state_variable("A_ARG_TYPE_Channel")
 
-        assert state_var.allowed_values == ["Master"]
+        assert state_var.allowed_values == {"Master"}
 
         # should be ok
         state_var.value = "Master"

--- a/tests/test_upnp_client.py
+++ b/tests/test_upnp_client.py
@@ -229,6 +229,7 @@ class TestUpnpStateVariable:
         state_var = service.state_variable("A_ARG_TYPE_Channel")
 
         assert state_var.allowed_values == {"Master"}
+        assert state_var.normalized_allowed_values == {"master"}
 
         # should be ok
         state_var.value = "Master"


### PR DESCRIPTION
AFAICT these are defined from the spec so they shouldn't change?

allowed_values was being calculated every time state was written

![allowed_values](https://github.com/StevenLooman/async_upnp_client/assets/663432/e9202473-4b06-4ca8-bc0d-628191479941)
