### PR TITLE
Support service WANIPConnection:2 in IGD profile

### DIFF
--- a/async_upnp_client/profiles/igd.py
+++ b/async_upnp_client/profiles/igd.py
@@ -148,6 +148,7 @@ class IgdDevice(UpnpProfileDevice):
         },
         "WANIPC": {
             "urn:schemas-upnp-org:service:WANIPConnection:1",
+            "urn:schemas-upnp-org:service:WANIPConnection:2",
         },
         "WANCIC": {
             "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",

--- a/changes/206.bugfix
+++ b/changes/206.bugfix
@@ -1,0 +1,1 @@
+Support service WANIPConnection:2 in IGD profile


### PR DESCRIPTION
Support service WANIPConnection:2 in IGD profile. Via https://github.com/home-assistant/core/issues/91488