### PR TITLE
Bump python-didl-lite to 1.4.0

### DIFF
--- a/changes/212.misc
+++ b/changes/212.misc
@@ -1,0 +1,1 @@
+Bump python-didl-lite to 1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
 	aiohttp~=3.9.0;python_version>='3.12'
 	aiohttp~=3.8.5;python_version<'3.12'
 	async-timeout >=3.0, <5.0
-	python-didl-lite ~= 1.3.2
+	python-didl-lite ~= 1.4.0
 	defusedxml >= 0.6.0
 tests_require = 
 	pytest ~= 7.4.3


### PR DESCRIPTION
Bump python-didl-lite to 1.4.0 for https://github.com/StevenLooman/python-didl-lite/pull/11