### PR TITLE
Rerelease of 0.37.0

### DIFF
--- a/changes/214.misc
+++ b/changes/214.misc
@@ -1,0 +1,1 @@
+Rerelease of 0.37.0


### PR DESCRIPTION
Rerelease of 0.37.0. Due to invalid release 0.37.0 and deleting it from pypi.