### PR TITLE
Added check that album art uri is a valid string

### DIFF
--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -1195,9 +1195,8 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         for item in items:
             # Some players use Item.albumArtURI,
             # though not found in the UPnP-av-ConnectionManager-v1-Service spec.
-            if hasattr(item, "album_art_uri"):
-                if item.album_art_uri is not None:
-                    return absolute_url(device_url, item.album_art_uri)
+            if hasattr(item, "album_art_uri") and item.album_art_uri is not None:
+                return absolute_url(device_url, item.album_art_uri)
 
             for res in item.resources:
                 protocol_info = res.protocol_info or ""

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -1196,7 +1196,8 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
             # Some players use Item.albumArtURI,
             # though not found in the UPnP-av-ConnectionManager-v1-Service spec.
             if hasattr(item, "album_art_uri"):
-                return absolute_url(device_url, item.album_art_uri)
+                if item.album_art_uri is not None:
+                    return absolute_url(device_url, item.album_art_uri)
 
             for res in item.resources:
                 protocol_info = res.protocol_info or ""

--- a/changes/215.bugfix
+++ b/changes/215.bugfix
@@ -1,0 +1,1 @@
+Prevent error when album_art_uri is `None` (@darrynlowe)


### PR DESCRIPTION
Some Samsung TVs return a profile that has an "album_art_uri" property set to None. As-was, this caused a string handling error in the absolute_url call. Fix is to simply check that the uri is not null before the call.