### PR TITLE
Avoid calling lower to delete _source header for combined_headers

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -196,7 +196,7 @@ class SsdpDevice:
                 assert isinstance(search_headers, CaseInsensitiveDict)
                 assert isinstance(advertisement_headers, CaseInsensitiveDict)
             header_dict = search_headers.combine(advertisement_headers)
-            del header_dict["_source"]
+            header_dict.del_lower("_source")
             return header_dict
         if search_headers is not _SENTINEL:
             if TYPE_CHECKING:

--- a/async_upnp_client/utils.py
+++ b/async_upnp_client/utils.py
@@ -147,6 +147,11 @@ class CaseInsensitiveDict(abcMutableMapping):
                 for k in self._data
             }
 
+    def del_lower(self, lower_key: str) -> None:
+        """Delete a lower case key."""
+        del self._data[self._case_map[lower_key]]
+        del self._case_map[lower_key]
+
     def __setitem__(self, key: str, value: Any) -> None:
         """Set item."""
         lower_key = key.lower()

--- a/changes/216.misc
+++ b/changes/216.misc
@@ -1,0 +1,1 @@
+Avoid calling lower to delete _source header for combined_headers (@bdraco)


### PR DESCRIPTION
This is a tiny optimization. I only noticed it while testing, but since there are ~300 calls per minute, I figured I would clean it up