### PR TITLE
Cache the parsing of didl_lite.from_xml_string for dlna profile

### DIFF
--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -232,6 +232,13 @@ def _lower_split_commas(input_: str) -> Set[str]:
     return {a.lower() for a in split_commas(input_)}
 
 
+@lru_cache
+def _cached_from_xml_string(
+    xml: str,
+) -> List[Union[didl_lite.DidlObject, didl_lite.Descriptor]]:
+    return didl_lite.from_xml_string(xml, strict=False)
+
+
 class ConnectionManagerMixin(UpnpProfileDevice):
     """Mix-in to support ConnectionManager actions and state variables."""
 
@@ -1075,7 +1082,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
             self._current_track_meta_data = None
             return
 
-        items = didl_lite.from_xml_string(xml, strict=False)
+        items = _cached_from_xml_string(xml, strict=False)
         if not items:
             self._current_track_meta_data = None
             return
@@ -1187,7 +1194,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         if not xml or xml == "NOT_IMPLEMENTED":
             return None
 
-        items = didl_lite.from_xml_string(xml, strict=False)
+        items = _cached_from_xml_string(xml, strict=False)
         if not items:
             return None
 
@@ -1258,7 +1265,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
             self._av_transport_uri_meta_data = None
             return
 
-        items = didl_lite.from_xml_string(xml, strict=False)
+        items = _cached_from_xml_string(xml, strict=False)
         if not items:
             self._av_transport_uri_meta_data = None
             return

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -1082,7 +1082,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
             self._current_track_meta_data = None
             return
 
-        items = _cached_from_xml_string(xml, strict=False)
+        items = _cached_from_xml_string(xml)
         if not items:
             self._current_track_meta_data = None
             return
@@ -1194,7 +1194,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         if not xml or xml == "NOT_IMPLEMENTED":
             return None
 
-        items = _cached_from_xml_string(xml, strict=False)
+        items = _cached_from_xml_string(xml)
         if not items:
             return None
 
@@ -1265,7 +1265,7 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
             self._av_transport_uri_meta_data = None
             return
 
-        items = _cached_from_xml_string(xml, strict=False)
+        items = _cached_from_xml_string(xml)
         if not items:
             self._av_transport_uri_meta_data = None
             return

--- a/changes/217.misc
+++ b/changes/217.misc
@@ -1,0 +1,1 @@
+Cache the parsing of didl_lite.from_xml_string for dlna profile


### PR DESCRIPTION
This rarely changes, but we parse it every time the entity updates in HA
<img width="1491" alt="Screenshot 2024-02-10 at 9 57 51 AM" src="https://github.com/StevenLooman/async_upnp_client/assets/663432/481a48e9-f162-4579-9533-a25b5914e6e2">
