### PR TITLE
Subscribe to IGD to reduce number of polls

### DIFF
--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -133,7 +133,7 @@ class UpnpEventHandler:
             return HTTPStatus.PRECONDITION_FAILED
 
         sid: ServiceId = headers["SID"]
-        service = self._subscriptions.get(sid)
+        service = self.service_for_sid(sid)
 
         # SID not known yet? store it in the backlog
         # Some devices don't behave nicely and send events before the SUBSCRIBE call is done.
@@ -217,7 +217,9 @@ class UpnpEventHandler:
 
         sid: ServiceId = response_headers["sid"]
         self._subscriptions[sid] = service
-        _LOGGER.debug("Got SID: %s, timeout: %s", sid, timeout)
+        _LOGGER.debug(
+            "Subscribed, service: %s, SID: %s, timeout: %s", service, sid, timeout
+        )
 
         # replay any backlog we have for this service
         if sid in self._backlog:
@@ -269,7 +271,9 @@ class UpnpEventHandler:
             timeout = timedelta(seconds=timeout_seconds)
 
         self._subscriptions[sid] = service
-        _LOGGER.debug("Got SID: %s, timeout: %s", sid, timeout)
+        _LOGGER.debug(
+            "Resubscribed, service: %s, SID: %s, timeout: %s", service, sid, timeout
+        )
 
         return sid, timeout
 

--- a/async_upnp_client/profiles/igd.py
+++ b/async_upnp_client/profiles/igd.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from enum import Enum
 from ipaddress import IPv4Address
-from typing import List, NamedTuple, Optional, Sequence, Union, cast
+from typing import List, NamedTuple, Optional, Sequence, Set, Union, cast
 
 from async_upnp_client.client import UpnpAction, UpnpDevice
 from async_upnp_client.event_handler import UpnpEventHandler
@@ -354,18 +354,22 @@ class IgdDevice(UpnpProfileDevice):
 
         result = await action.async_call(NewPortMappingIndex=port_mapping_index)
         return PortMappingEntry(
-            IPv4Address(result["NewRemoteHost"])
-            if result.get("NewRemoteHost")
-            else None,
+            (
+                IPv4Address(result["NewRemoteHost"])
+                if result.get("NewRemoteHost")
+                else None
+            ),
             result["NewExternalPort"],
             result["NewProtocol"],
             result["NewInternalPort"],
             IPv4Address(result["NewInternalClient"]),
             result["NewEnabled"],
             result["NewPortMappingDescription"],
-            timedelta(seconds=result["NewLeaseDuration"])
-            if result.get("NewLeaseDuration")
-            else None,
+            (
+                timedelta(seconds=result["NewLeaseDuration"])
+                if result.get("NewLeaseDuration")
+                else None
+            ),
         )
 
     async def async_get_specific_port_mapping_entry(
@@ -401,9 +405,11 @@ class IgdDevice(UpnpProfileDevice):
             IPv4Address(result["NewInternalClient"]),
             result["NewEnabled"],
             result["NewPortMappingDescription"],
-            timedelta(seconds=result["NewLeaseDuration"])
-            if result.get("NewLeaseDuration")
-            else None,
+            (
+                timedelta(seconds=result["NewLeaseDuration"])
+                if result.get("NewLeaseDuration")
+                else None
+            ),
         )
 
     async def async_add_port_mapping(
@@ -641,7 +647,7 @@ class IgdDevice(UpnpProfileDevice):
 
     async def async_get_traffic_and_status_data(
         self,
-        items: Optional[set[IgdStateItem]] = None,
+        items: Optional[Set[IgdStateItem]] = None,
         force_poll: bool = False,
     ) -> IgdState:
         """
@@ -694,30 +700,42 @@ class IgdDevice(UpnpProfileDevice):
 
         timestamp = datetime.now()
         values = await asyncio.gather(
-            self.async_get_total_bytes_received()
-            if IgdStateItem.BYTES_RECEIVED in items
-            or IgdStateItem.KIBIBYTES_PER_SEC_RECEIVED in items
-            else nop(),
-            self.async_get_total_bytes_sent()
-            if IgdStateItem.BYTES_SENT in items
-            or IgdStateItem.KIBIBYTES_PER_SEC_SENT in items
-            else nop(),
-            self.async_get_total_packets_received()
-            if IgdStateItem.PACKETS_RECEIVED in items
-            or IgdStateItem.PACKETS_PER_SEC_RECEIVED in items
-            else nop(),
-            self.async_get_total_packets_sent()
-            if IgdStateItem.PACKETS_SENT in items
-            or IgdStateItem.PACKETS_PER_SEC_SENT in items
-            else nop(),
-            self.async_get_status_info()
-            if IgdStateItem.CONNECTION_STATUS in items
-            or IgdStateItem.LAST_CONNECTION_ERROR in items
-            or IgdStateItem.UPTIME in items
-            else nop(),
-            self.async_get_external_ip_address()
-            if IgdStateItem.EXTERNAL_IP_ADDRESS in items
-            else nop(),
+            (
+                self.async_get_total_bytes_received()
+                if IgdStateItem.BYTES_RECEIVED in items
+                or IgdStateItem.KIBIBYTES_PER_SEC_RECEIVED in items
+                else nop()
+            ),
+            (
+                self.async_get_total_bytes_sent()
+                if IgdStateItem.BYTES_SENT in items
+                or IgdStateItem.KIBIBYTES_PER_SEC_SENT in items
+                else nop()
+            ),
+            (
+                self.async_get_total_packets_received()
+                if IgdStateItem.PACKETS_RECEIVED in items
+                or IgdStateItem.PACKETS_PER_SEC_RECEIVED in items
+                else nop()
+            ),
+            (
+                self.async_get_total_packets_sent()
+                if IgdStateItem.PACKETS_SENT in items
+                or IgdStateItem.PACKETS_PER_SEC_SENT in items
+                else nop()
+            ),
+            (
+                self.async_get_status_info()
+                if IgdStateItem.CONNECTION_STATUS in items
+                or IgdStateItem.LAST_CONNECTION_ERROR in items
+                or IgdStateItem.UPTIME in items
+                else nop()
+            ),
+            (
+                self.async_get_external_ip_address()
+                if IgdStateItem.EXTERNAL_IP_ADDRESS in items
+                else nop()
+            ),
             return_exceptions=True,
         )
 
@@ -781,12 +799,12 @@ class IgdDevice(UpnpProfileDevice):
             kibibytes_per_sec_sent=kibibytes_per_sec_sent,
             packets_per_sec_received=packets_per_sec_received,
             packets_per_sec_sent=packets_per_sec_sent,
-            connection_status=values[4].connection_status
-            if values[4]
-            else connection_status,
-            last_connection_error=values[4].last_connection_error
-            if values[4]
-            else None,
+            connection_status=(
+                values[4].connection_status if values[4] else connection_status
+            ),
+            last_connection_error=(
+                values[4].last_connection_error if values[4] else None
+            ),
             uptime=values[4].uptime if values[4] else None,
             external_ip_address=values[5] or external_ip_address,
         )

--- a/async_upnp_client/profiles/igd.py
+++ b/async_upnp_client/profiles/igd.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from enum import Enum
 from ipaddress import IPv4Address
-from typing import AbstractSet, List, NamedTuple, Optional, Sequence, Union, cast
+from typing import List, NamedTuple, Optional, Sequence, Union, cast
 
 from async_upnp_client.client import UpnpAction, UpnpDevice
 from async_upnp_client.event_handler import UpnpEventHandler
@@ -93,7 +93,9 @@ class IgdState(NamedTuple):
     bytes_sent: Union[None, BaseException, int]
     packets_received: Union[None, BaseException, int]
     packets_sent: Union[None, BaseException, int]
-    status_info: Union[None, BaseException, StatusInfo]
+    connection_status: Union[None, BaseException, str]
+    last_connection_error: Union[None, BaseException, str]
+    uptime: Union[None, BaseException, int]
     external_ip_address: Union[None, BaseException, str]
 
     # Derived values.
@@ -115,8 +117,10 @@ class IgdStateItem(Enum):
     PACKETS_RECEIVED = 3
     PACKETS_SENT = 4
 
-    STATUS_INFO = 5
-    EXTERNAL_IP_ADDRESS = 6
+    CONNECTION_STATUS = 5
+    LAST_CONNECTION_ERROR = 6
+    UPTIME = 7
+    EXTERNAL_IP_ADDRESS = 8
 
     KIBIBYTES_PER_SEC_RECEIVED = 11
     KIBIBYTES_PER_SEC_SENT = 12
@@ -636,7 +640,9 @@ class IgdDevice(UpnpProfileDevice):
         await action.async_call(NewDefaultConnectionService=service)
 
     async def async_get_traffic_and_status_data(
-        self, items: Optional[AbstractSet[IgdStateItem]] = None
+        self,
+        items: Optional[set[IgdStateItem]] = None,
+        force_poll: bool = False,
     ) -> IgdState:
         """
         Get all traffic data at once, including derived data.
@@ -654,17 +660,37 @@ class IgdDevice(UpnpProfileDevice):
           * connection status
           * uptime
         """
+        # pylint: disable=too-many-locals
         items = items or {
             IgdStateItem.BYTES_RECEIVED,
             IgdStateItem.BYTES_SENT,
             IgdStateItem.PACKETS_RECEIVED,
             IgdStateItem.PACKETS_SENT,
-            IgdStateItem.STATUS_INFO,
+            IgdStateItem.CONNECTION_STATUS,
+            IgdStateItem.LAST_CONNECTION_ERROR,
+            IgdStateItem.UPTIME,
             IgdStateItem.EXTERNAL_IP_ADDRESS,
         }
 
         async def nop() -> None:
             """Pass."""
+
+        external_ip_address: Optional[str] = None
+        connection_status: Optional[str] = None
+        if not force_poll:
+            for service_type in ["WANIPC", "WANPPP"]:
+                if (service := self._service(service_type)) is not None:
+                    # Get ExternalIPAddress from state variables.
+                    if service.has_state_variable("ExternalIPAddress"):
+                        state_var = service.state_variable("ExternalIPAddress")
+                        if (external_ip_address := state_var.value) is not None:
+                            items.remove(IgdStateItem.EXTERNAL_IP_ADDRESS)
+
+                    # Get ConnectionStatus from state variables.
+                    if service.has_state_variable("ConnectionStatus"):
+                        state_var = service.state_variable("ConnectionStatus")
+                        if (connection_status := state_var.value) is not None:
+                            items.remove(IgdStateItem.CONNECTION_STATUS)
 
         timestamp = datetime.now()
         values = await asyncio.gather(
@@ -685,7 +711,9 @@ class IgdDevice(UpnpProfileDevice):
             or IgdStateItem.PACKETS_PER_SEC_SENT in items
             else nop(),
             self.async_get_status_info()
-            if IgdStateItem.STATUS_INFO in items
+            if IgdStateItem.CONNECTION_STATUS in items
+            or IgdStateItem.LAST_CONNECTION_ERROR in items
+            or IgdStateItem.UPTIME in items
             else nop(),
             self.async_get_external_ip_address()
             if IgdStateItem.EXTERNAL_IP_ADDRESS in items
@@ -753,6 +781,12 @@ class IgdDevice(UpnpProfileDevice):
             kibibytes_per_sec_sent=kibibytes_per_sec_sent,
             packets_per_sec_received=packets_per_sec_received,
             packets_per_sec_sent=packets_per_sec_sent,
-            status_info=values[4],
-            external_ip_address=values[5],
+            connection_status=values[4].connection_status
+            if values[4]
+            else connection_status,
+            last_connection_error=values[4].last_connection_error
+            if values[4]
+            else None,
+            uptime=values[4].uptime if values[4] else None,
+            external_ip_address=values[5] or external_ip_address,
         )

--- a/changes/231.feature
+++ b/changes/231.feature
@@ -1,0 +1,5 @@
+Subscribe to IGD to reduce number of polls.
+
+This also simplifies the returned IgdState from IgdDevice.async_get_traffic_and_status_data(), as the items from StatusInfo are now diectly added to IgdState.
+
+As a bonus, extend the dummy_router to support subscribing and use evented state variables ExternalIPAddress and ConnectionStatus.

--- a/contrib/dummy_router.py
+++ b/contrib/dummy_router.py
@@ -12,12 +12,13 @@ import asyncio
 import logging
 import xml.etree.ElementTree as ET
 from time import time
-from typing import Dict, Mapping, Sequence, Type
+from typing import Dict, Mapping, Sequence, Type, cast
 
 from async_upnp_client.client import UpnpRequester, UpnpStateVariable
 from async_upnp_client.const import (
     STATE_VARIABLE_TYPE_MAPPING,
     DeviceInfo,
+    EventableStateVariableTypeInfo,
     ServiceInfo,
     StateVariableTypeInfo,
 )
@@ -46,15 +47,16 @@ class WANIPConnectionService(UpnpServerService):
     )
 
     STATE_VARIABLE_DEFINITIONS = {
-        "ExternalIPAddress": StateVariableTypeInfo(
+        "ExternalIPAddress": EventableStateVariableTypeInfo(
             data_type="string",
             data_type_mapping=STATE_VARIABLE_TYPE_MAPPING["string"],
-            default_value="1.2.3.4",
+            default_value="1.2.3.0",
             allowed_value_range={},
             allowed_values=None,
+            max_rate=None,
             xml=ET.Element("server_stateVariable"),
         ),
-        "ConnectionStatus": StateVariableTypeInfo(
+        "ConnectionStatus": EventableStateVariableTypeInfo(
             data_type="string",
             data_type_mapping=STATE_VARIABLE_TYPE_MAPPING["string"],
             default_value="Unconfigured",
@@ -68,6 +70,7 @@ class WANIPConnectionService(UpnpServerService):
                 "Disconnecting",
                 "Disconnected",
             ],
+            max_rate=None,
             xml=ET.Element("server_stateVariable"),
         ),
         "LastConnectionError": StateVariableTypeInfo(
@@ -364,9 +367,16 @@ async def async_main(server: UpnpServer) -> None:
     """Main."""
     await server.async_start()
 
+    loop_no = 0
     while True:
-        await asyncio.sleep(3600)
+        upnp_service = server._device.find_service("urn:schemas-upnp-org:service:WANIPConnection:1")
+        wanipc_service = cast(WANIPConnectionService, upnp_service)
+        external_ip_address_var = wanipc_service.state_variable("ExternalIPAddress")
+        external_ip_address_var.value = f"1.2.3.{(loop_no % 255) + 1}"
 
+        await asyncio.sleep(30)
+
+        loop_no += 1
 
 async def async_stop(server: UpnpServer) -> None:
     await server.async_stop()


### PR DESCRIPTION
Subscribe to IGD to reduce number of polls.

This also simplifies the returned `IgdState` from `IgdDevice.async_get_traffic_and_status_data()`, as the items from `StatusInfo` are now diectly added to `IgdState`.

As a bonus, extend the `dummy_router` to support subscribing and use evented state variables `ExternalIPAddress` and `ConnectionStatus`.