### PR TITLE
Drop unused `--bind` option in `subscribe` command

### DIFF
--- a/async_upnp_client/cli.py
+++ b/async_upnp_client/cli.py
@@ -61,10 +61,6 @@ subparser.add_argument(
     "service", nargs="+", help="service type or part or abbreviation"
 )
 subparser.add_argument(
-    "--bind",
-    help="ip to bind to, e.g., 192.168.0.10",
-)
-subparser.add_argument(
     "--nolastchange", action="store_true", help="Do not show LastChange events"
 )
 

--- a/changes/232.bugfix
+++ b/changes/232.bugfix
@@ -1,0 +1,1 @@
+Drop unused `--bind` option in `subscribe` command in cli/`upnp-client`.


### PR DESCRIPTION
Drop unused `--bind` option in `subscribe` command