### PR TITLE
Add pre-/post-hooks when doing/handling HTTP requests

### DIFF
--- a/async_upnp_client/aiohttp.py
+++ b/async_upnp_client/aiohttp.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from asyncio.events import AbstractEventLoop, AbstractServer
 from ipaddress import ip_address
-from typing import Dict, Mapping, Optional, Tuple
+from typing import Dict, Mapping, Optional
 from urllib.parse import urlparse
 
 import aiohttp.web
@@ -17,7 +17,12 @@ from aiohttp import (
 )
 
 from async_upnp_client.client import UpnpRequester
-from async_upnp_client.const import AddressTupleVXType, IPvXAddress
+from async_upnp_client.const import (
+    AddressTupleVXType,
+    HttpRequest,
+    HttpResponse,
+    IPvXAddress,
+)
 from async_upnp_client.event_handler import UpnpEventHandler, UpnpNotifyServer
 from async_upnp_client.exceptions import (
     UpnpClientResponseError,
@@ -64,34 +69,35 @@ class AiohttpRequester(UpnpRequester):
 
     async def async_http_request(
         self,
-        method: str,
-        url: str,
-        headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
-    ) -> Tuple[int, Mapping, str]:
+        http_request: HttpRequest,
+    ) -> HttpResponse:
         """Do a HTTP request."""
         req_headers = {
-            **_fixed_host_header(url),
+            **_fixed_host_header(http_request.url),
             **self._http_headers,
-            **(headers or {}),
+            **(http_request.headers or {}),
         }
 
         log_traffic = _LOGGER_TRAFFIC_UPNP.isEnabledFor(logging.DEBUG)
         if log_traffic:  # pragma: no branch
             _LOGGER_TRAFFIC_UPNP.debug(
                 "Sending request:\n%s %s\n%s\n%s\n",
-                method,
-                url,
+                http_request.method,
+                http_request.url,
                 "\n".join(
                     [key + ": " + value for key, value in (req_headers or {}).items()]
                 ),
-                body or "",
+                http_request.body or "",
             )
 
         try:
             async with ClientSession() as session:
                 async with session.request(
-                    method, url, headers=req_headers, data=body, timeout=self._timeout
+                    http_request.method,
+                    http_request.url,
+                    headers=req_headers,
+                    data=http_request.body,
+                    timeout=self._timeout,
                 ) as response:
                     status = response.status
                     resp_headers: Mapping = response.headers or {}
@@ -100,8 +106,8 @@ class AiohttpRequester(UpnpRequester):
                     if log_traffic:  # pragma: no branch
                         _LOGGER_TRAFFIC_UPNP.debug(
                             "Got response from %s %s:\n%s\n%s\n\n%s",
-                            method,
-                            url,
+                            http_request.method,
+                            http_request.url,
                             status,
                             "\n".join(
                                 [
@@ -130,7 +136,7 @@ class AiohttpRequester(UpnpRequester):
         except UnicodeDecodeError as err:
             raise UpnpCommunicationError(repr(err)) from err
 
-        return status, resp_headers, resp_body_text
+        return HttpResponse(status, resp_headers, resp_body_text)
 
 
 class AiohttpSessionRequester(UpnpRequester):
@@ -157,11 +163,8 @@ class AiohttpSessionRequester(UpnpRequester):
 
     async def async_http_request(
         self,
-        method: str,
-        url: str,
-        headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
-    ) -> Tuple[int, Mapping[str, str], str]:
+        http_request: HttpRequest,
+    ) -> HttpResponse:
         """Do a HTTP request with a retry on ServerDisconnectedError.
 
         The HTTP/1.1 spec allows the server to disconnect at any time.
@@ -169,39 +172,41 @@ class AiohttpSessionRequester(UpnpRequester):
         """
         for _ in range(2):
             try:
-                return await self._async_http_request(method, url, headers, body)
+                return await self._async_http_request(http_request)
             except ClientConnectionError as err:
-                _LOGGER.debug("%r during request %s %s; retrying", err, method, url)
+                _LOGGER.debug(
+                    "%r during request %s %s; retrying",
+                    err,
+                    http_request.method,
+                    http_request.url,
+                )
         try:
-            return await self._async_http_request(method, url, headers, body)
+            return await self._async_http_request(http_request)
         except ClientConnectionError as err:
             raise UpnpConnectionError(repr(err)) from err
 
     async def _async_http_request(
         self,
-        method: str,
-        url: str,
-        headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
-    ) -> Tuple[int, Mapping[str, str], str]:
+        http_request: HttpRequest,
+    ) -> HttpResponse:
         """Do a HTTP request."""
         # pylint: disable=too-many-arguments
         req_headers = {
-            **_fixed_host_header(url),
+            **_fixed_host_header(http_request.url),
             **self._http_headers,
-            **(headers or {}),
+            **(http_request.headers or {}),
         }
 
         log_traffic = _LOGGER_TRAFFIC_UPNP.isEnabledFor(logging.DEBUG)
         if log_traffic:  # pragma: no branch
             _LOGGER_TRAFFIC_UPNP.debug(
                 "Sending request:\n%s %s\n%s\n%s\n",
-                method,
-                url,
+                http_request.method,
+                http_request.url,
                 "\n".join(
                     [key + ": " + value for key, value in (req_headers or {}).items()]
                 ),
-                body or "",
+                http_request.body or "",
             )
 
         if self._with_sleep:
@@ -209,7 +214,11 @@ class AiohttpSessionRequester(UpnpRequester):
 
         try:
             async with self._session.request(
-                method, url, headers=req_headers, data=body, timeout=self._timeout
+                http_request.method,
+                http_request.url,
+                headers=req_headers,
+                data=http_request.body,
+                timeout=self._timeout,
             ) as response:
                 status = response.status
                 resp_headers: Mapping = response.headers or {}
@@ -218,8 +227,8 @@ class AiohttpSessionRequester(UpnpRequester):
                 if log_traffic:  # pragma: no branch
                     _LOGGER_TRAFFIC_UPNP.debug(
                         "Got response from %s %s:\n%s\n%s\n\n%s",
-                        method,
-                        url,
+                        http_request.method,
+                        http_request.url,
                         status,
                         "\n".join(
                             [key + ": " + value for key, value in resp_headers.items()]
@@ -245,7 +254,7 @@ class AiohttpSessionRequester(UpnpRequester):
         except UnicodeDecodeError as err:
             raise UpnpCommunicationError(repr(err)) from err
 
-        return status, resp_headers, resp_body_text
+        return HttpResponse(status, resp_headers, resp_body_text)
 
 
 class AiohttpNotifyServer(UpnpNotifyServer):
@@ -332,7 +341,10 @@ class AiohttpNotifyServer(UpnpNotifyServer):
             _LOGGER.debug("Not notify")
             return aiohttp.web.Response(status=405)
 
-        status = await self.event_handler.handle_notify(headers, body)
+        http_request = HttpRequest(
+            request.method, self.callback_url, request.headers, body
+        )
+        status = await self.event_handler.handle_notify(http_request)
         _LOGGER.debug("NOTIFY response status: %s", status)
         if log_traffic:
             _LOGGER_TRAFFIC_UPNP.debug("Sending response: %s", status)

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -33,7 +33,6 @@ from async_upnp_client.const import (
     NS,
     ActionArgumentInfo,
     ActionInfo,
-    DescriptionSort,
     DeviceIcon,
     DeviceInfo,
     HttpRequest,
@@ -57,18 +56,27 @@ _LOGGER = logging.getLogger(__name__)
 EventCallbackType = Callable[["UpnpService", Sequence["UpnpStateVariable"]], None]
 
 
-def default_on_pre_receive_spec(
-    description_sort: DescriptionSort, request: HttpRequest
-) -> HttpRequest:
-    """Pre-receive specification hook."""
+def default_on_pre_receive_device_spec(request: HttpRequest) -> HttpRequest:
+    """Pre-receive device specification hook."""
     # pylint: disable=unused-argument
     return request
 
 
-def default_on_post_receive_spec(
-    description_sort: DescriptionSort, response: HttpResponse
-) -> HttpResponse:
-    """Post-receive specification hook."""
+def default_on_post_receive_device_spec(response: HttpResponse) -> HttpResponse:
+    """Post-receive device specification hook."""
+    # pylint: disable=unused-argument
+    fixed_body = (response.body or "").rstrip(" \t\r\n\0")
+    return HttpResponse(response.status_code, response.headers, fixed_body)
+
+
+def default_on_pre_receive_service_spec(request: HttpRequest) -> HttpRequest:
+    """Pre-receive service specification hook."""
+    # pylint: disable=unused-argument
+    return request
+
+
+def default_on_post_receive_service_spec(response: HttpResponse) -> HttpResponse:
+    """Post-receive service specification hook."""
     # pylint: disable=unused-argument
     fixed_body = (response.body or "").rstrip(" \t\r\n\0")
     return HttpResponse(response.status_code, response.headers, fixed_body)
@@ -147,12 +155,12 @@ class UpnpDevice:
         device_info: DeviceInfo,
         services: Sequence["UpnpService"],
         embedded_devices: Sequence["UpnpDevice"],
-        on_pre_receive_spec: Callable[
-            [DescriptionSort, HttpRequest], HttpRequest
-        ] = default_on_pre_receive_spec,
-        on_post_receive_spec: Callable[
-            [DescriptionSort, HttpResponse], HttpResponse
-        ] = default_on_post_receive_spec,
+        on_pre_receive_device_spec: Callable[
+            [HttpRequest], HttpRequest
+        ] = default_on_pre_receive_device_spec,
+        on_post_receive_device_spec: Callable[
+            [HttpResponse], HttpResponse
+        ] = default_on_post_receive_device_spec,
     ) -> None:
         """Initialize."""
         # pylint: disable=too-many-arguments
@@ -163,8 +171,8 @@ class UpnpDevice:
             embedded_device.device_type: embedded_device
             for embedded_device in embedded_devices
         }
-        self.on_pre_receive_spec = on_pre_receive_spec
-        self.on_post_receive_spec = on_post_receive_spec
+        self.on_pre_receive_device_spec = on_pre_receive_device_spec
+        self.on_post_receive_device_spec = on_post_receive_device_spec
 
         self._parent_device: Optional["UpnpDevice"] = None
 
@@ -371,9 +379,7 @@ class UpnpDevice:
     async def async_ping(self) -> None:
         """Ping the device."""
         bare_request = HttpRequest("GET", self.device_url, {}, None)
-        request = self.on_pre_receive_spec(
-            DescriptionSort.DEVICE_DESCRIPTION, bare_request
-        )
+        request = self.on_pre_receive_device_spec(bare_request)
         await self.requester.async_http_request(request)
 
     def __str__(self) -> str:
@@ -394,8 +400,10 @@ class UpnpService:
         actions: Sequence["UpnpAction"],
         on_pre_call_action: Callable[
             ["UpnpAction", Mapping[str, Any], HttpRequest], HttpRequest
-        ],
-        on_post_call_action: Callable[["UpnpAction", HttpResponse], HttpResponse],
+        ] = default_on_pre_call_action,
+        on_post_call_action: Callable[
+            ["UpnpAction", HttpResponse], HttpResponse
+        ] = default_on_post_call_action,
     ) -> None:
         """Initialize."""
         # pylint: disable=too-many-arguments

--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -19,7 +19,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Type,
     TypeVar,
 )
@@ -34,8 +33,11 @@ from async_upnp_client.const import (
     NS,
     ActionArgumentInfo,
     ActionInfo,
+    DescriptionSort,
     DeviceIcon,
     DeviceInfo,
+    HttpRequest,
+    HttpResponse,
     ServiceInfo,
     StateVariableInfo,
 )
@@ -53,6 +55,40 @@ _LOGGER = logging.getLogger(__name__)
 
 
 EventCallbackType = Callable[["UpnpService", Sequence["UpnpStateVariable"]], None]
+
+
+def default_on_pre_receive_spec(
+    description_sort: DescriptionSort, request: HttpRequest
+) -> HttpRequest:
+    """Pre-receive specification hook."""
+    # pylint: disable=unused-argument
+    return request
+
+
+def default_on_post_receive_spec(
+    description_sort: DescriptionSort, response: HttpResponse
+) -> HttpResponse:
+    """Post-receive specification hook."""
+    # pylint: disable=unused-argument
+    fixed_body = (response.body or "").rstrip(" \t\r\n\0")
+    return HttpResponse(response.status_code, response.headers, fixed_body)
+
+
+def default_on_pre_call_action(
+    action: "UpnpAction", args: Mapping[str, Any], request: HttpRequest
+) -> HttpRequest:
+    """Pre-action call hook."""
+    # pylint: disable=unused-argument
+    return request
+
+
+def default_on_post_call_action(
+    action: "UpnpAction", response: HttpResponse
+) -> HttpResponse:
+    """Post-action call hook."""
+    # pylint: disable=unused-argument
+    fixed_body = (response.body or "").rstrip(" \t\r\n\0")
+    return HttpResponse(response.status_code, response.headers, fixed_body)
 
 
 class DisableXmlNamespaces:
@@ -94,28 +130,16 @@ class UpnpRequester(ABC):
 
     async def async_http_request(
         self,
-        method: str,
-        url: str,
-        headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
-    ) -> Tuple[int, Mapping[str, str], str]:
-        """
-        Do a HTTP request.
-
-        :param method HTTP Method
-        :param url URL to call
-        :param headers Headers to send
-        :param body Body to send
-
-        :return status code, headers, body
-        """
+        http_request: HttpRequest,
+    ) -> HttpResponse:
+        """Do a HTTP request."""
         raise NotImplementedError()
 
 
 class UpnpDevice:
     """UPnP Device representation."""
 
-    # pylint: disable=too-many-public-methods
+    # pylint: disable=too-many-public-methods,too-many-instance-attributes
 
     def __init__(
         self,
@@ -123,6 +147,12 @@ class UpnpDevice:
         device_info: DeviceInfo,
         services: Sequence["UpnpService"],
         embedded_devices: Sequence["UpnpDevice"],
+        on_pre_receive_spec: Callable[
+            [DescriptionSort, HttpRequest], HttpRequest
+        ] = default_on_pre_receive_spec,
+        on_post_receive_spec: Callable[
+            [DescriptionSort, HttpResponse], HttpResponse
+        ] = default_on_post_receive_spec,
     ) -> None:
         """Initialize."""
         # pylint: disable=too-many-arguments
@@ -133,6 +163,9 @@ class UpnpDevice:
             embedded_device.device_type: embedded_device
             for embedded_device in embedded_devices
         }
+        self.on_pre_receive_spec = on_pre_receive_spec
+        self.on_post_receive_spec = on_post_receive_spec
+
         self._parent_device: Optional["UpnpDevice"] = None
 
         # bind services to ourselves
@@ -337,7 +370,11 @@ class UpnpDevice:
 
     async def async_ping(self) -> None:
         """Ping the device."""
-        await self.requester.async_http_request("GET", self.device_url)
+        bare_request = HttpRequest("GET", self.device_url, {}, None)
+        request = self.on_pre_receive_spec(
+            DescriptionSort.DEVICE_DESCRIPTION, bare_request
+        )
+        await self.requester.async_http_request(request)
 
     def __str__(self) -> str:
         """To string."""
@@ -355,12 +392,19 @@ class UpnpService:
         service_info: ServiceInfo,
         state_variables: Sequence["UpnpStateVariable"],
         actions: Sequence["UpnpAction"],
+        on_pre_call_action: Callable[
+            ["UpnpAction", Mapping[str, Any], HttpRequest], HttpRequest
+        ],
+        on_post_call_action: Callable[["UpnpAction", HttpResponse], HttpResponse],
     ) -> None:
         """Initialize."""
+        # pylint: disable=too-many-arguments
         self.requester = requester
         self._service_info = service_info
         self.state_variables = {sv.name: sv for sv in state_variables}
         self.actions = {ac.name: ac for ac in actions}
+        self.on_pre_call_action = on_pre_call_action
+        self.on_post_call_action = on_post_call_action
 
         self.on_event: Optional[EventCallbackType] = None
         self._device: Optional[UpnpDevice] = None
@@ -662,24 +706,22 @@ class UpnpAction:
         """Call an action with arguments."""
         # do request
         _LOGGER.debug("Calling action: %s, args: %s", self.name, kwargs)
-        url, headers, body = self.create_request(**kwargs)
-        (
-            status_code,
-            response_headers,
-            response_body,
-        ) = await self.service.requester.async_http_request("POST", url, headers, body)
-        if not isinstance(response_body, str):
+        bare_request = self.create_request(**kwargs)
+        request = self.service.on_pre_call_action(self, kwargs, bare_request)
+        bare_response = await self.service.requester.async_http_request(request)
+        response = self.service.on_post_call_action(self, bare_response)
+        if not isinstance(response.body, str):
             raise UpnpError(
                 f"Did not receive a body when calling action: {self.name}, args: {kwargs}"
             )
 
-        if status_code != 200:
+        if response.status_code != 200:
             try:
-                xml = DET.fromstring(response_body.strip(" \t\r\n\0"))
+                xml = DET.fromstring(response.body)
             except ET.ParseError:
                 pass
             else:
-                self._parse_fault(xml, status_code, response_headers)
+                self._parse_fault(xml, response.status_code, response.headers)
 
             # Couldn't parse body for fault details, raise generic response error
             _LOGGER.debug(
@@ -688,19 +730,17 @@ class UpnpAction:
                 kwargs,
             )
             raise UpnpResponseError(
-                status=status_code,
-                headers=response_headers,
+                status=response.status_code,
+                headers=response.headers,
                 message=f"Error during async_call(), "
                 f"action: {self.name}, "
                 f"args: {kwargs}, "
-                f"status: {status_code}, "
-                f"body: {response_body}",
+                f"status: {response.status_code}, "
+                f"body: {response.body}",
             )
 
         # parse body
-        response_args = self.parse_response(
-            self.service.service_type, response_headers, response_body
-        )
+        response_args = self.parse_response(self.service.service_type, response)
         _LOGGER.debug(
             "Called action: %s, args: %s, response_args: %s",
             self.name,
@@ -709,8 +749,8 @@ class UpnpAction:
         )
         return response_args
 
-    def create_request(self, **kwargs: Any) -> Tuple[str, Mapping[str, str], str]:
-        """Create headers and headers for this to-be-called UpnpAction."""
+    def create_request(self, **kwargs: Any) -> HttpRequest:
+        """Create HTTP request for this to-be-called UpnpAction."""
         # build URL
         control_url = self.service.control_url
 
@@ -737,7 +777,7 @@ class UpnpAction:
             "Content-Type": 'text/xml; charset="utf-8"',
         }
 
-        return control_url, headers, body
+        return HttpRequest("POST", control_url, headers, body)
 
     def _format_request_args(self, **kwargs: Any) -> str:
         self.validate_arguments(**kwargs)
@@ -748,11 +788,11 @@ class UpnpAction:
         return "\n".join(arg_strs)
 
     def parse_response(
-        self, service_type: str, response_headers: Mapping, response_body: str
+        self, service_type: str, http_response: HttpResponse
     ) -> Mapping[str, Any]:
         """Parse response from called Action."""
         # pylint: disable=unused-argument
-        stripped_response_body = response_body.rstrip(" \t\r\n\0")
+        stripped_response_body = http_response.body
         try:
             xml = DET.fromstring(stripped_response_body)
         except ET.ParseError as err:
@@ -770,11 +810,13 @@ class UpnpAction:
                     xml = it_root
                 except ET.ParseError as err2:
                     _LOGGER.debug(
-                        "Unable to parse XML: %s\nXML:\n%s", err2, response_body
+                        "Unable to parse XML: %s\nXML:\n%s", err2, http_response.body
                     )
                     raise UpnpXmlParseError(err2) from err2
             else:
-                _LOGGER.debug("Unable to parse XML: %s\nXML:\n%s", err, response_body)
+                _LOGGER.debug(
+                    "Unable to parse XML: %s\nXML:\n%s", err, http_response.body
+                )
                 raise UpnpXmlParseError(err) from err
 
         # Check if a SOAP fault occurred. It should have been caught earlier, by
@@ -784,7 +826,7 @@ class UpnpAction:
         try:
             return self._parse_response_args(service_type, xml)
         except AttributeError:
-            _LOGGER.debug("Could not parse response: %s", response_body)
+            _LOGGER.debug("Could not parse response: %s", http_response.body)
             raise
 
     def _parse_response_args(

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -432,19 +432,7 @@ class UpnpFactory:
         request = self._on_pre_receive_device_spec(bare_request)
         bare_response = await self.requester.async_http_request(request)
         response = self._on_post_receive_device_spec(bare_response)
-
-        if response.status_code != 200:
-            raise UpnpResponseError(
-                status=response.status_code, headers=response.headers
-            )
-
-        description: str = response.body or ""
-        try:
-            element: ET.Element = DET.fromstring(description)
-            return element
-        except ET.ParseError as err:
-            _LOGGER.debug("Unable to parse XML: %s\nXML:\n%s", err, description)
-            raise UpnpXmlParseError(err) from err
+        return self._read_spec_from_reponse(response)
 
     async def _async_get_service_spec(self, url: str) -> ET.Element:
         """Get a url."""
@@ -452,7 +440,10 @@ class UpnpFactory:
         request = self._on_pre_receive_service_spec(bare_request)
         bare_response = await self.requester.async_http_request(request)
         response = self._on_post_receive_service_spec(bare_response)
+        return self._read_spec_from_reponse(response)
 
+    def _read_spec_from_reponse(self, response: HttpResponse) -> ET.Element:
+        """Read XML specification from response."""
         if response.status_code != 200:
             raise UpnpResponseError(
                 status=response.status_code, headers=response.headers

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -17,16 +17,17 @@ from async_upnp_client.client import (
     UpnpService,
     UpnpStateVariable,
     default_on_post_call_action,
-    default_on_post_receive_spec,
+    default_on_post_receive_device_spec,
+    default_on_post_receive_service_spec,
     default_on_pre_call_action,
-    default_on_pre_receive_spec,
+    default_on_pre_receive_device_spec,
+    default_on_pre_receive_service_spec,
 )
 from async_upnp_client.const import (
     NS,
     STATE_VARIABLE_TYPE_MAPPING,
     ActionArgumentInfo,
     ActionInfo,
-    DescriptionSort,
     DeviceIcon,
     DeviceInfo,
     HttpRequest,
@@ -54,18 +55,24 @@ class UpnpFactory:
     listening for advertisements.
     """
 
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods,too-many-instance-attributes
 
     def __init__(
         self,
         requester: UpnpRequester,
         non_strict: bool = False,
-        on_pre_receive_spec: Callable[
-            [DescriptionSort, HttpRequest], HttpRequest
-        ] = default_on_pre_receive_spec,
-        on_post_receive_spec: Callable[
-            [DescriptionSort, HttpResponse], HttpResponse
-        ] = default_on_post_receive_spec,
+        on_pre_receive_device_spec: Callable[
+            [HttpRequest], HttpRequest
+        ] = default_on_pre_receive_device_spec,
+        on_post_receive_device_spec: Callable[
+            [HttpResponse], HttpResponse
+        ] = default_on_post_receive_device_spec,
+        on_pre_receive_service_spec: Callable[
+            [HttpRequest], HttpRequest
+        ] = default_on_pre_receive_service_spec,
+        on_post_receive_service_spec: Callable[
+            [HttpResponse], HttpResponse
+        ] = default_on_post_receive_service_spec,
         on_pre_call_action: Callable[
             [UpnpAction, Mapping[str, Any], HttpRequest], HttpRequest
         ] = default_on_pre_call_action,
@@ -77,8 +84,10 @@ class UpnpFactory:
         # pylint: disable=too-many-arguments
         self.requester = requester
         self._non_strict = non_strict
-        self._on_pre_receive_spec = on_pre_receive_spec
-        self._on_post_receive_spec = on_post_receive_spec
+        self._on_pre_receive_device_spec = on_pre_receive_device_spec
+        self._on_post_receive_device_spec = on_post_receive_device_spec
+        self._on_pre_receive_service_spec = on_pre_receive_service_spec
+        self._on_post_receive_service_spec = on_post_receive_service_spec
         self._on_pre_call_action = on_pre_call_action
         self._on_post_call_action = on_post_call_action
 
@@ -88,9 +97,7 @@ class UpnpFactory:
     ) -> UpnpDevice:
         """Create a UpnpDevice, with all of it UpnpServices."""
         _LOGGER.debug("Creating device, description_url: %s", description_url)
-        root_el = await self._async_get(
-            DescriptionSort.DEVICE_DESCRIPTION, description_url
-        )
+        root_el = await self._async_get_device_spec(description_url)
 
         # get root device
         device_el = root_el.find("./device:device", NS)
@@ -127,8 +134,8 @@ class UpnpFactory:
             device_info,
             services,
             embedded_devices,
-            self._on_pre_receive_spec,
-            self._on_post_receive_spec,
+            self._on_pre_receive_device_spec,
+            self._on_post_receive_device_spec,
         )
 
     def _parse_device_el(
@@ -180,9 +187,7 @@ class UpnpFactory:
         scpd_url = urllib.parse.urljoin(base_url, scpd_url)
 
         try:
-            scpd_el = await self._async_get(
-                DescriptionSort.SERVICE_DESCRIPTION, scpd_url
-            )
+            scpd_el = await self._async_get_service_spec(scpd_url)
         except UpnpXmlParseError as err:
             if not self._non_strict:
                 raise
@@ -421,12 +426,32 @@ class UpnpFactory:
 
         return ActionInfo(name=action_name, arguments=args, xml=action_el)
 
-    async def _async_get(self, spec_sort: DescriptionSort, url: str) -> ET.Element:
+    async def _async_get_device_spec(self, url: str) -> ET.Element:
         """Get a url."""
         bare_request = HttpRequest("GET", url, {}, None)
-        request = self._on_pre_receive_spec(spec_sort, bare_request)
+        request = self._on_pre_receive_device_spec(bare_request)
         bare_response = await self.requester.async_http_request(request)
-        response = self._on_post_receive_spec(spec_sort, bare_response)
+        response = self._on_post_receive_device_spec(bare_response)
+
+        if response.status_code != 200:
+            raise UpnpResponseError(
+                status=response.status_code, headers=response.headers
+            )
+
+        description: str = response.body or ""
+        try:
+            element: ET.Element = DET.fromstring(description)
+            return element
+        except ET.ParseError as err:
+            _LOGGER.debug("Unable to parse XML: %s\nXML:\n%s", err, description)
+            raise UpnpXmlParseError(err) from err
+
+    async def _async_get_service_spec(self, url: str) -> ET.Element:
+        """Get a url."""
+        bare_request = HttpRequest("GET", url, {}, None)
+        request = self._on_pre_receive_service_spec(bare_request)
+        bare_response = await self.requester.async_http_request(request)
+        response = self._on_post_receive_service_spec(bare_response)
 
         if response.status_code != 200:
             raise UpnpResponseError(

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -3,7 +3,7 @@
 
 import logging
 import urllib.parse
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 from xml.etree import ElementTree as ET
 
 import defusedxml.ElementTree as DET
@@ -16,14 +16,21 @@ from async_upnp_client.client import (
     UpnpRequester,
     UpnpService,
     UpnpStateVariable,
+    default_on_post_call_action,
+    default_on_post_receive_spec,
+    default_on_pre_call_action,
+    default_on_pre_receive_spec,
 )
 from async_upnp_client.const import (
     NS,
     STATE_VARIABLE_TYPE_MAPPING,
     ActionArgumentInfo,
     ActionInfo,
+    DescriptionSort,
     DeviceIcon,
     DeviceInfo,
+    HttpRequest,
+    HttpResponse,
     ServiceInfo,
     StateVariableInfo,
     StateVariableTypeInfo,
@@ -42,8 +49,9 @@ class UpnpFactory:
     """
     Factory for UpnpService and friends.
 
-    Use UpnpFactory.async_create_device() to instantiate UpnpDevice from a device XML.
-    You have probably received this URL from netdisco, for example.
+    Use UpnpFactory.async_create_device() to instantiate a UpnpDevice from a description URL. The
+    description URL can be retrieved by searching for the UPnP device on the network, or by
+    listening for advertisements.
     """
 
     # pylint: disable=too-few-public-methods
@@ -51,17 +59,28 @@ class UpnpFactory:
     def __init__(
         self,
         requester: UpnpRequester,
-        disable_state_variable_validation: bool = False,
-        disable_unknown_out_argument_error: bool = False,
         non_strict: bool = False,
+        on_pre_receive_spec: Callable[
+            [DescriptionSort, HttpRequest], HttpRequest
+        ] = default_on_pre_receive_spec,
+        on_post_receive_spec: Callable[
+            [DescriptionSort, HttpResponse], HttpResponse
+        ] = default_on_post_receive_spec,
+        on_pre_call_action: Callable[
+            [UpnpAction, Mapping[str, Any], HttpRequest], HttpRequest
+        ] = default_on_pre_call_action,
+        on_post_call_action: Callable[
+            [UpnpAction, HttpResponse], HttpResponse
+        ] = default_on_post_call_action,
     ) -> None:
         """Initialize."""
+        # pylint: disable=too-many-arguments
         self.requester = requester
-        self._non_strict = (
-            non_strict
-            or disable_unknown_out_argument_error
-            or disable_state_variable_validation
-        )
+        self._non_strict = non_strict
+        self._on_pre_receive_spec = on_pre_receive_spec
+        self._on_post_receive_spec = on_post_receive_spec
+        self._on_pre_call_action = on_pre_call_action
+        self._on_post_call_action = on_post_call_action
 
     async def async_create_device(
         self,
@@ -69,7 +88,9 @@ class UpnpFactory:
     ) -> UpnpDevice:
         """Create a UpnpDevice, with all of it UpnpServices."""
         _LOGGER.debug("Creating device, description_url: %s", description_url)
-        root_el = await self._async_get(description_url)
+        root_el = await self._async_get(
+            DescriptionSort.DEVICE_DESCRIPTION, description_url
+        )
 
         # get root device
         device_el = root_el.find("./device:device", NS)
@@ -101,7 +122,14 @@ class UpnpFactory:
             )
             embedded_devices.append(embedded_device)
 
-        return UpnpDevice(self.requester, device_info, services, embedded_devices)
+        return UpnpDevice(
+            self.requester,
+            device_info,
+            services,
+            embedded_devices,
+            self._on_pre_receive_spec,
+            self._on_post_receive_spec,
+        )
 
     def _parse_device_el(
         self, device_desc_el: ET.Element, description_url: str
@@ -152,8 +180,9 @@ class UpnpFactory:
         scpd_url = urllib.parse.urljoin(base_url, scpd_url)
 
         try:
-            scpd_el = await self._async_get(scpd_url)
-
+            scpd_el = await self._async_get(
+                DescriptionSort.SERVICE_DESCRIPTION, scpd_url
+            )
         except UpnpXmlParseError as err:
             if not self._non_strict:
                 raise
@@ -166,7 +195,14 @@ class UpnpFactory:
         service_info = self._parse_service_el(service_description_el)
         state_vars = self._create_state_variables(scpd_el)
         actions = self._create_actions(scpd_el, state_vars)
-        return UpnpService(self.requester, service_info, state_vars, actions)
+        return UpnpService(
+            self.requester,
+            service_info,
+            state_vars,
+            actions,
+            self._on_pre_call_action,
+            self._on_post_call_action,
+        )
 
     def _parse_service_el(self, service_description_el: ET.Element) -> ServiceInfo:
         """Parse service description XML."""
@@ -385,18 +421,19 @@ class UpnpFactory:
 
         return ActionInfo(name=action_name, arguments=args, xml=action_el)
 
-    async def _async_get(self, url: str) -> ET.Element:
+    async def _async_get(self, spec_sort: DescriptionSort, url: str) -> ET.Element:
         """Get a url."""
-        (
-            status_code,
-            response_headers,
-            response_body,
-        ) = await self.requester.async_http_request("GET", url)
+        bare_request = HttpRequest("GET", url, {}, None)
+        request = self._on_pre_receive_spec(spec_sort, bare_request)
+        bare_response = await self.requester.async_http_request(request)
+        response = self._on_post_receive_spec(spec_sort, bare_response)
 
-        if status_code != 200:
-            raise UpnpResponseError(status=status_code, headers=response_headers)
+        if response.status_code != 200:
+            raise UpnpResponseError(
+                status=response.status_code, headers=response.headers
+            )
 
-        description: str = (response_body or "").rstrip(" \t\r\n\0")
+        description: str = response.body or ""
         try:
             element: ET.Element = DET.fromstring(description)
             return element

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -156,6 +156,32 @@ class ActionInfo(NamedTuple):
     xml: ET.Element
 
 
+class DescriptionSort(Enum):
+    """Specification sort."""
+
+    DEVICE_DESCRIPTION = 1
+    SERVICE_DESCRIPTION = 2
+
+
+@dataclass(frozen=True)
+class HttpRequest:
+    """HTTP request."""
+
+    method: str
+    url: str
+    headers: Mapping[str, str]
+    body: Optional[str]
+
+
+@dataclass(frozen=True)
+class HttpResponse:
+    """HTTP response."""
+
+    status_code: int
+    headers: Mapping[str, str]
+    body: Optional[str]
+
+
 @dataclass(frozen=True)
 class StateVariableTypeInfo:
     """State variable type info."""

--- a/async_upnp_client/const.py
+++ b/async_upnp_client/const.py
@@ -156,13 +156,6 @@ class ActionInfo(NamedTuple):
     xml: ET.Element
 
 
-class DescriptionSort(Enum):
-    """Specification sort."""
-
-    DEVICE_DESCRIPTION = 1
-    SERVICE_DESCRIPTION = 2
-
-
 @dataclass(frozen=True)
 class HttpRequest:
     """HTTP request."""

--- a/async_upnp_client/description_cache.py
+++ b/async_upnp_client/description_cache.py
@@ -9,6 +9,7 @@ import aiohttp
 import defusedxml.ElementTree as DET
 
 from async_upnp_client.client import UpnpRequester
+from async_upnp_client.const import HttpRequest
 from async_upnp_client.exceptions import UpnpResponseError
 from async_upnp_client.utils import etree_to_dict
 
@@ -51,6 +52,7 @@ class DescriptionCache:
         except Exception:  # pylint: disable=broad-except
             # If it fails, cache the failure so we do not keep trying over and over
             _LOGGER.exception("Failed to fetch description from: %s", location)
+
         return None
 
     def peek_description_dict(
@@ -105,12 +107,14 @@ class DescriptionCache:
         """Download a description from location."""
         try:
             for _ in range(2):
-                status, headers, body = await self._requester.async_http_request(
-                    "GET", location
-                )
-                if status != 200:
-                    raise UpnpResponseError(status=status, headers=headers)
-                return body
+                request = HttpRequest("GET", location, {}, None)
+                response = await self._requester.async_http_request(request)
+                if response.status_code != 200:
+                    raise UpnpResponseError(
+                        status=response.status_code, headers=response.headers
+                    )
+
+                return response.body
                 # Samsung Smart TV sometimes returns an empty document the
                 # first time. Retry once.
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/async_upnp_client/event_handler.py
+++ b/async_upnp_client/event_handler.py
@@ -8,13 +8,13 @@ from abc import ABC
 from datetime import timedelta
 from http import HTTPStatus
 from ipaddress import ip_address
-from typing import Dict, Mapping, Optional, Set, Tuple, Type, Union
+from typing import Callable, Dict, Optional, Set, Tuple, Type, Union
 from urllib.parse import urlparse
 
 import defusedxml.ElementTree as DET
 
 from async_upnp_client.client import UpnpDevice, UpnpRequester, UpnpService
-from async_upnp_client.const import NS, IPvXAddress, ServiceId
+from async_upnp_client.const import NS, HttpRequest, IPvXAddress, ServiceId
 from async_upnp_client.exceptions import (
     UpnpConnectionError,
     UpnpError,
@@ -24,6 +24,13 @@ from async_upnp_client.exceptions import (
 from async_upnp_client.utils import get_local_ip
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def default_on_pre_notify(request: HttpRequest) -> HttpRequest:
+    """Pre-notify hook."""
+    # pylint: disable=unused-argument
+    fixed_body = (request.body or "").rstrip(" \t\r\n\0")
+    return HttpRequest(request.method, request.url, request.headers, fixed_body)
 
 
 class UpnpNotifyServer(ABC):
@@ -64,6 +71,7 @@ class UpnpEventHandler:
         self,
         notify_server: UpnpNotifyServer,
         requester: UpnpRequester,
+        on_pre_notify: Callable[[HttpRequest], HttpRequest] = default_on_pre_notify,
     ) -> None:
         """
         Initialize.
@@ -72,11 +80,12 @@ class UpnpEventHandler:
         """
         self._notify_server = notify_server
         self._requester = requester
+        self.on_pre_notify = on_pre_notify
 
-        self._subscriptions: weakref.WeakValueDictionary[
-            ServiceId, UpnpService
-        ] = weakref.WeakValueDictionary()
-        self._backlog: Dict[ServiceId, Tuple[Mapping, str]] = {}
+        self._subscriptions: weakref.WeakValueDictionary[ServiceId, UpnpService] = (
+            weakref.WeakValueDictionary()
+        )
+        self._backlog: Dict[ServiceId, HttpRequest] = {}
 
     @property
     def callback_url(self) -> str:
@@ -119,37 +128,35 @@ class UpnpEventHandler:
 
         return sid, service
 
-    async def handle_notify(self, headers: Mapping[str, str], body: str) -> HTTPStatus:
+    async def handle_notify(self, http_request: HttpRequest) -> HTTPStatus:
         """Handle a NOTIFY request."""
+        http_request = self.on_pre_notify(http_request)
+
         # ensure valid request
-        if "NT" not in headers or "NTS" not in headers:
+        if "NT" not in http_request.headers or "NTS" not in http_request.headers:
             return HTTPStatus.BAD_REQUEST
 
         if (
-            headers["NT"] != "upnp:event"
-            or headers["NTS"] != "upnp:propchange"
-            or "SID" not in headers
+            http_request.headers["NT"] != "upnp:event"
+            or http_request.headers["NTS"] != "upnp:propchange"
+            or "SID" not in http_request.headers
         ):
             return HTTPStatus.PRECONDITION_FAILED
 
-        sid: ServiceId = headers["SID"]
+        sid: ServiceId = http_request.headers["SID"]
         service = self.service_for_sid(sid)
 
         # SID not known yet? store it in the backlog
         # Some devices don't behave nicely and send events before the SUBSCRIBE call is done.
         if not service:
             _LOGGER.debug("Storing NOTIFY in backlog for SID: %s", sid)
-            self._backlog[sid] = (
-                headers,
-                body,
-            )
+            self._backlog[sid] = http_request
 
             return HTTPStatus.OK
 
         # decode event and send updates to service
         changes = {}
-        stripped_body = body.rstrip(" \t\r\n\0")
-        el_root = DET.fromstring(stripped_body)
+        el_root = DET.fromstring(http_request.body)
         for el_property in el_root.findall("./event:property", NS):
             for el_state_var in el_property:
                 name = el_state_var.tag
@@ -192,30 +199,31 @@ class UpnpEventHandler:
             "HOST": urlparse(service.event_sub_url).netloc,
             "CALLBACK": f"<{self.callback_url}>",
         }
-        response_status, response_headers, _ = await self._requester.async_http_request(
-            "SUBSCRIBE", service.event_sub_url, headers
-        )
+        backlog_request = HttpRequest("SUBSCRIBE", service.event_sub_url, headers, None)
+        response = await self._requester.async_http_request(backlog_request)
 
         # check results
-        if response_status != 200:
-            _LOGGER.debug("Did not receive 200, but %s", response_status)
-            raise UpnpResponseError(status=response_status, headers=response_headers)
+        if response.status_code != 200:
+            _LOGGER.debug("Did not receive 200, but %s", response.status_code)
+            raise UpnpResponseError(
+                status=response.status_code, headers=response.headers
+            )
 
-        if "sid" not in response_headers:
+        if "sid" not in response.headers:
             _LOGGER.debug("No SID received, aborting subscribe")
             raise UpnpSIDError
 
         # Device can give a different TIMEOUT header than what we have provided.
         if (
-            "timeout" in response_headers
-            and response_headers["timeout"] != "Second-infinite"
-            and "Second-" in response_headers["timeout"]
+            "timeout" in response.headers
+            and response.headers["timeout"] != "Second-infinite"
+            and "Second-" in response.headers["timeout"]
         ):
-            response_timeout = response_headers["timeout"]
+            response_timeout = response.headers["timeout"]
             timeout_seconds = int(response_timeout[7:])  # len("Second-") == 7
             timeout = timedelta(seconds=timeout_seconds)
 
-        sid: ServiceId = response_headers["sid"]
+        sid: ServiceId = response.headers["sid"]
         self._subscriptions[sid] = service
         _LOGGER.debug(
             "Subscribed, service: %s, SID: %s, timeout: %s", service, sid, timeout
@@ -224,8 +232,8 @@ class UpnpEventHandler:
         # replay any backlog we have for this service
         if sid in self._backlog:
             _LOGGER.debug("Re-playing backlogged NOTIFY for SID: %s", sid)
-            item = self._backlog[sid]
-            await self.handle_notify(item[0], item[1])
+            backlog_request = self._backlog[sid]
+            await self.handle_notify(backlog_request)
             del self._backlog[sid]
 
         return sid, timeout
@@ -243,30 +251,31 @@ class UpnpEventHandler:
             "SID": sid,
             "TIMEOUT": "Second-" + str(timeout.total_seconds()),
         }
-        response_status, response_headers, _ = await self._requester.async_http_request(
-            "SUBSCRIBE", service.event_sub_url, headers
-        )
+        request = HttpRequest("SUBSCRIBE", service.event_sub_url, headers, None)
+        response = await self._requester.async_http_request(request)
 
         # check results
-        if response_status != 200:
-            _LOGGER.debug("Did not receive 200, but %s", response_status)
-            raise UpnpResponseError(status=response_status, headers=response_headers)
+        if response.status_code != 200:
+            _LOGGER.debug("Did not receive 200, but %s", response.status_code)
+            raise UpnpResponseError(
+                status=response.status_code, headers=response.headers
+            )
 
         # Devices should return the SID when re-subscribe,
         # but in case it doesn't, use the new SID.
-        if "sid" in response_headers and response_headers["sid"]:
-            new_sid: ServiceId = response_headers["sid"]
+        if "sid" in response.headers and response.headers["sid"]:
+            new_sid: ServiceId = response.headers["sid"]
             if new_sid != sid:
                 del self._subscriptions[sid]
                 sid = new_sid
 
         # Device can give a different TIMEOUT header than what we have provided.
         if (
-            "timeout" in response_headers
-            and response_headers["timeout"] != "Second-infinite"
-            and "Second-" in response_headers["timeout"]
+            "timeout" in response.headers
+            and response.headers["timeout"] != "Second-infinite"
+            and "Second-" in response.headers["timeout"]
         ):
-            response_timeout = response_headers["timeout"]
+            response_timeout = response.headers["timeout"]
             timeout_seconds = int(response_timeout[7:])  # len("Second-") == 7
             timeout = timedelta(seconds=timeout_seconds)
 
@@ -349,14 +358,15 @@ class UpnpEventHandler:
             "HOST": urlparse(service.event_sub_url).netloc,
             "SID": sid,
         }
-        response_status, response_headers, _ = await self._requester.async_http_request(
-            "UNSUBSCRIBE", service.event_sub_url, headers
-        )
+        request = HttpRequest("UNSUBSCRIBE", service.event_sub_url, headers, None)
+        response = await self._requester.async_http_request(request)
 
         # check results
-        if response_status != 200:
-            _LOGGER.debug("Did not receive 200, but %s", response_status)
-            raise UpnpResponseError(status=response_status, headers=response_headers)
+        if response.status_code != 200:
+            _LOGGER.debug("Did not receive 200, but %s", response.status_code)
+            raise UpnpResponseError(
+                status=response.status_code, headers=response.headers
+            )
 
         return sid
 

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -31,7 +31,7 @@ from defusedxml.sax import parseString
 from didl_lite import didl_lite
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
-from async_upnp_client.const import MIME_TO_UPNP_CLASS_MAPPING
+from async_upnp_client.const import MIME_TO_UPNP_CLASS_MAPPING, HttpRequest
 from async_upnp_client.exceptions import UpnpError
 from async_upnp_client.profiles.profile import UpnpProfileDevice
 from async_upnp_client.utils import absolute_url, str_to_time, time_to_str
@@ -892,27 +892,28 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
         requester = self.profile_device.requester
 
         # try a HEAD first
-        status, rsp_hdrs, _ = await requester.async_http_request("HEAD", url, headers)
-        if 200 <= status < 300:
-            return rsp_hdrs
+        request = HttpRequest("HEAD", url, headers, None)
+        response = await requester.async_http_request(request)
+        if 200 <= response.status_code < 300:
+            return response.headers
 
-        if status == HTTPStatus.NOT_FOUND:
+        if response.status_code == HTTPStatus.NOT_FOUND:
             # Give up when the item doesn't exist, otherwise try GET below
             return None
 
         # then try a GET request for only the first byte of content
         get_headers = dict(headers)
         get_headers["Range"] = "bytes=0-0"
-        status, rsp_hdrs, _ = await requester.async_http_request(
-            "GET", url, get_headers
-        )
-        if 200 <= status < 300:
-            return rsp_hdrs
+        request = HttpRequest("GET", url, get_headers, None)
+        response = await requester.async_http_request(request)
+        if 200 <= response.status_code < 300:
+            return response.headers
 
         # finally try a plain GET, which might return a lot of data
-        status, rsp_hdrs, _ = await requester.async_http_request("GET", url, headers)
-        if 200 <= status < 300:
-            return rsp_hdrs
+        request = HttpRequest("GET", url, headers, None)
+        response = await requester.async_http_request(request)
+        if 200 <= response.status_code < 300:
+            return response.headers
 
         return None
 

--- a/async_upnp_client/server.py
+++ b/async_upnp_client/server.py
@@ -63,6 +63,7 @@ from async_upnp_client.const import (
     AddressTupleVXType,
     DeviceInfo,
     EventableStateVariableTypeInfo,
+    HttpRequest,
     NotificationSubType,
     ServiceInfo,
     StateVariableInfo,
@@ -409,7 +410,7 @@ class UpnpServerService(UpnpService):
             hdr["SEQ"] = str(sub.get_next_seq())
             tasks.append(
                 self.requester.async_http_request(
-                    "NOTIFY", sub.url, headers=hdr, body=message
+                    HttpRequest("NOTIFY", sub.url, headers=hdr, body=message)
                 )
             )
         await asyncio.gather(*tasks)
@@ -1013,9 +1014,9 @@ class UpnpXmlSerializer:
         arg_el = ET.Element("argument")
         ET.SubElement(arg_el, "name").text = argument.name
         ET.SubElement(arg_el, "direction").text = argument.direction
-        ET.SubElement(
-            arg_el, "relatedStateVariable"
-        ).text = argument.related_state_variable.name
+        ET.SubElement(arg_el, "relatedStateVariable").text = (
+            argument.related_state_variable.name
+        )
         return arg_el
 
     @classmethod
@@ -1153,9 +1154,7 @@ def _create_error_action_response(
     error_code = (
         exception.error_code or UpnpActionErrorCode.ACTION_FAILED.value
         if isinstance(exception, UpnpActionError)
-        else 402
-        if isinstance(exception, UpnpValueError)
-        else 501
+        else 402 if isinstance(exception, UpnpValueError) else 501
     )
     ET.SubElement(error_el, "errorCode").text = str(error_code)
     ET.SubElement(error_el, "errorDescription").text = "Action Failed"

--- a/changes/233.feature
+++ b/changes/233.feature
@@ -1,0 +1,3 @@
+Add pre-/post-hooks when doing/handling HTTP requests.
+
+Includes refactoring of Tuples to HttpRequest/HttpResponse, causing in breaking changes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from typing import Deque, Mapping, MutableMapping, Optional, Tuple, cast
 
 from async_upnp_client.client import UpnpRequester
-from async_upnp_client.const import AddressTupleVXType
+from async_upnp_client.const import AddressTupleVXType, HttpRequest, HttpResponse
 from async_upnp_client.event_handler import UpnpEventHandler, UpnpNotifyServer
 
 
@@ -26,22 +26,18 @@ class UpnpTestRequester(UpnpRequester):
 
     def __init__(
         self,
-        response_map: Mapping[Tuple[str, str], Tuple[int, Mapping[str, str], str]],
+        response_map: Mapping[Tuple[str, str], HttpResponse],
     ) -> None:
         """Class initializer."""
-        self.response_map: MutableMapping[
-            Tuple[str, str],
-            Tuple[int, MutableMapping[str, str], str],
-        ] = deepcopy(cast(MutableMapping, response_map))
+        self.response_map: MutableMapping[Tuple[str, str], HttpResponse] = deepcopy(
+            cast(MutableMapping, response_map)
+        )
         self.exceptions: Deque[Optional[Exception]] = deque()
 
     async def async_http_request(
         self,
-        method: str,
-        url: str,
-        headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
-    ) -> Tuple[int, Mapping, str]:
+        http_request: HttpRequest,
+    ) -> HttpResponse:
         """Do a HTTP request."""
         await asyncio.sleep(0.01)
 
@@ -50,144 +46,146 @@ class UpnpTestRequester(UpnpRequester):
             if exception is not None:
                 raise exception
 
-        key = (method, url)
+        key = (http_request.method, http_request.url)
         if key not in self.response_map:
             raise KeyError(f"Request not in response map: {key}")
 
         return self.response_map[key]
 
 
-RESPONSE_MAP: Mapping[Tuple[str, str], Tuple[int, Mapping[str, str], str]] = {
+RESPONSE_MAP: Mapping[Tuple[str, str], HttpResponse] = {
     # DLNA/DMR
-    ("GET", "http://dlna_dmr:1234/device.xml"): (
+    ("GET", "http://dlna_dmr:1234/device.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/device.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/device_embedded.xml"): (
+    ("GET", "http://dlna_dmr:1234/device_embedded.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/device_embedded.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/device_incomplete.xml"): (
+    ("GET", "http://dlna_dmr:1234/device_incomplete.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/device_incomplete.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/device_with_empty_descriptor.xml"): (
+    ("GET", "http://dlna_dmr:1234/device_with_empty_descriptor.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/device_with_empty_descriptor.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/RenderingControl_1.xml"): (
+    ("GET", "http://dlna_dmr:1234/RenderingControl_1.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/RenderingControl_1.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/ConnectionManager_1.xml"): (
+    ("GET", "http://dlna_dmr:1234/ConnectionManager_1.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/ConnectionManager_1.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/AVTransport_1.xml"): (
+    ("GET", "http://dlna_dmr:1234/AVTransport_1.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/AVTransport_1.xml"),
     ),
-    ("GET", "http://dlna_dmr:1234/Empty_Descriptor.xml"): (
+    ("GET", "http://dlna_dmr:1234/Empty_Descriptor.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dmr/Empty_Descriptor.xml"),
     ),
-    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/ConnectionManager1"): (
+    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/ConnectionManager1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-cm1", "timeout": "Second-175"},
         "",
     ),
-    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1"): (
+    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1"): HttpResponse(
         200,
         {"sid": "uuid:dummy", "timeout": "Second-300"},
         "",
     ),
-    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/AVTransport1"): (
+    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/AVTransport1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-avt1", "timeout": "Second-150"},
         "",
     ),
-    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/QPlay"): (
+    ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/QPlay"): HttpResponse(
         200,
         {"sid": "uuid:dummy-qp1", "timeout": "Second-150"},
         "",
     ),
-    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/ConnectionManager1"): (
+    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/ConnectionManager1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-cm1"},
         "",
     ),
-    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1"): (
+    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1"): HttpResponse(
         200,
         {"sid": "uuid:dummy"},
         "",
     ),
-    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/AVTransport1"): (
+    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/AVTransport1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-avt1"},
         "",
     ),
-    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/QPlay"): (
+    ("UNSUBSCRIBE", "http://dlna_dmr:1234/upnp/event/QPlay"): HttpResponse(
         200,
         {"sid": "uuid:dummy-qp1"},
         "",
     ),
     # DLNA/DMS
-    ("GET", "http://dlna_dms:1234/device.xml"): (
+    ("GET", "http://dlna_dms:1234/device.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dms/device.xml"),
     ),
-    ("GET", "http://dlna_dms:1234/ConnectionManager_1.xml"): (
+    ("GET", "http://dlna_dms:1234/ConnectionManager_1.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dms/ConnectionManager_1.xml"),
     ),
-    ("GET", "http://dlna_dms:1234/ContentDirectory_1.xml"): (
+    ("GET", "http://dlna_dms:1234/ContentDirectory_1.xml"): HttpResponse(
         200,
         {},
         read_file("dlna/dms/ContentDirectory_1.xml"),
     ),
-    ("SUBSCRIBE", "http://dlna_dms:1234/upnp/event/ConnectionManager1"): (
+    ("SUBSCRIBE", "http://dlna_dms:1234/upnp/event/ConnectionManager1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-cm1", "timeout": "Second-150"},
         "",
     ),
-    ("SUBSCRIBE", "http://dlna_dms:1234/upnp/event/ContentDirectory1"): (
+    ("SUBSCRIBE", "http://dlna_dms:1234/upnp/event/ContentDirectory1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-cd1", "timeout": "Second-150"},
         "",
     ),
-    ("UNSUBSCRIBE", "http://dlna_dms:1234/upnp/event/ConnectionManager1"): (
+    ("UNSUBSCRIBE", "http://dlna_dms:1234/upnp/event/ConnectionManager1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-cm1"},
         "",
     ),
-    ("UNSUBSCRIBE", "http://dlna_dms:1234/upnp/event/ContentDirectory1"): (
+    ("UNSUBSCRIBE", "http://dlna_dms:1234/upnp/event/ContentDirectory1"): HttpResponse(
         200,
         {"sid": "uuid:dummy-cd1"},
         "",
     ),
     # IGD
-    ("GET", "http://igd:1234/device.xml"): (200, {}, read_file("igd/device.xml")),
-    ("GET", "http://igd:1234/Layer3Forwarding.xml"): (
+    ("GET", "http://igd:1234/device.xml"): HttpResponse(
+        200, {}, read_file("igd/device.xml")
+    ),
+    ("GET", "http://igd:1234/Layer3Forwarding.xml"): HttpResponse(
         200,
         {},
         read_file("igd/Layer3Forwarding.xml"),
     ),
-    ("GET", "http://igd:1234/WANCommonInterfaceConfig.xml"): (
+    ("GET", "http://igd:1234/WANCommonInterfaceConfig.xml"): HttpResponse(
         200,
         {},
         read_file("igd/WANCommonInterfaceConfig.xml"),
     ),
-    ("GET", "http://igd:1234/WANIPConnection.xml"): (
+    ("GET", "http://igd:1234/WANIPConnection.xml"): HttpResponse(
         200,
         {},
         read_file("igd/WANIPConnection.xml"),

--- a/tests/profiles/test_dlna_dmr.py
+++ b/tests/profiles/test_dlna_dmr.py
@@ -12,6 +12,7 @@ from didl_lite import didl_lite
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.const import HttpRequest, HttpResponse
 from async_upnp_client.profiles.dlna import (
     DmrDevice,
     _parse_last_change_event,
@@ -181,7 +182,10 @@ async def test_on_notify_dlna_event() -> None:
 </e:propertyset>
 """
 
-    result = await event_handler.handle_notify(headers, body)
+    http_request = HttpRequest(
+        "NOTIFY", "http://dlna_dmr:1234/upnp/event/RenderingControl1", headers, body
+    )
+    result = await event_handler.handle_notify(http_request)
     assert result == 200
 
     assert len(changed_vars) == 3
@@ -205,10 +209,13 @@ async def test_wait_for_can_play_evented() -> None:
     await profile.async_subscribe_services()
 
     # Send a NOTIFY of CurrentTransportActions without Play
-    result = await event_handler.handle_notify(
+    http_request = HttpRequest(
+        "NOTIFY",
+        "http://dlna_dmr:1234/upnp/event/AVTransport1",
         AVT_NOTIFY_HEADERS,
         AVT_CURRENT_TRANSPORT_ACTIONS_NOTIFY_BODY_FMT.format(actions="Stop"),
     )
+    result = await event_handler.handle_notify(http_request)
     assert result == 200
 
     # Should not be able to play yet
@@ -219,10 +226,13 @@ async def test_wait_for_can_play_evented() -> None:
     async def delayed_notify() -> None:
         await asyncio.sleep(0.1)
         # Send NOTIFY of change to CurrentTransportActions
-        result = await event_handler.handle_notify(
+        http_request = HttpRequest(
+            "NOTIFY",
+            "http://dlna_dmr:1234/upnp/event/AVTransport1",
             AVT_NOTIFY_HEADERS,
             AVT_CURRENT_TRANSPORT_ACTIONS_NOTIFY_BODY_FMT.format(actions="Pause,Play"),
         )
+        result = await event_handler.handle_notify(http_request)
         assert result == 200
 
     loop = asyncio.get_event_loop()
@@ -253,7 +263,7 @@ async def test_wait_for_can_play_polled() -> None:
     # Polling of CurrentTransportActions does not contain "Play" yet
     requester.response_map[
         ("POST", "http://dlna_dmr:1234/upnp/control/AVTransport1")
-    ] = (
+    ] = HttpResponse(
         200,
         {},
         read_file("dlna/dmr/action_GetCurrentTransportActions_Stop.xml"),
@@ -270,7 +280,7 @@ async def test_wait_for_can_play_polled() -> None:
     # Polling of CurrentTransportActions now contains "Play"
     requester.response_map[
         ("POST", "http://dlna_dmr:1234/upnp/control/AVTransport1")
-    ] = (
+    ] = HttpResponse(
         200,
         {},
         read_file("dlna/dmr/action_GetCurrentTransportActions_PlaySeek.xml"),
@@ -297,7 +307,7 @@ async def test_wait_for_can_play_timeout() -> None:
     # Polling of CurrentTransportActions does not contain "Play" yet
     requester.response_map[
         ("POST", "http://dlna_dmr:1234/upnp/control/AVTransport1")
-    ] = (
+    ] = HttpResponse(
         200,
         {},
         read_file("dlna/dmr/action_GetCurrentTransportActions_Stop.xml"),
@@ -535,7 +545,7 @@ http://dlna_dms:4321/object/file_1222
     )
 
     # Media server supplies media information for HEAD requests
-    requester.response_map[("HEAD", media_url)] = (
+    requester.response_map[("HEAD", media_url)] = HttpResponse(
         200,
         {
             "ContentFeatures.dlna.org": "DLNA_SERVER_FEATURES",
@@ -543,7 +553,7 @@ http://dlna_dms:4321/object/file_1222
         },
         "",
     )
-    requester.response_map[("HEAD", media_url + ".mp3")] = (
+    requester.response_map[("HEAD", media_url + ".mp3")] = HttpResponse(
         200,
         {
             "ContentFeatures.dlna.org": "DLNA_SERVER_FEATURES",

--- a/tests/profiles/test_dlna_dmr.py
+++ b/tests/profiles/test_dlna_dmr.py
@@ -349,9 +349,11 @@ async def test_fetch_headers() -> None:
     with mock.patch.object(
         profile.profile_device.requester, "async_http_request"
     ) as ahr_mock:
-        ahr_mock.side_effect = [(200, expected_response_headers, "")]
+        ahr_mock.side_effect = [HttpResponse(200, expected_response_headers, "")]
         headers = await profile._fetch_headers(media_url, fetch_headers)
-        ahr_mock.assert_awaited_once_with("HEAD", media_url, fetch_headers)
+        ahr_mock.assert_awaited_once_with(
+            HttpRequest("HEAD", media_url, fetch_headers, None)
+        )
         assert headers == expected_response_headers
 
     # HEAD method is not allowed, but GET with Range works
@@ -361,13 +363,17 @@ async def test_fetch_headers() -> None:
         ranged_response_headers = dict(expected_response_headers)
         ranged_response_headers["Content-Range"] = "bytes 0-0/1024"
         ahr_mock.side_effect = [
-            (405, expected_response_headers, ""),
-            (200, ranged_response_headers, ""),
+            HttpResponse(405, expected_response_headers, ""),
+            HttpResponse(200, ranged_response_headers, ""),
         ]
         headers = await profile._fetch_headers(media_url, fetch_headers)
         assert ahr_mock.await_args_list == [
-            mock.call("HEAD", media_url, fetch_headers),
-            mock.call("GET", media_url, dict(fetch_headers, Range="bytes=0-0")),
+            mock.call(HttpRequest("HEAD", media_url, fetch_headers, None)),
+            mock.call(
+                HttpRequest(
+                    "GET", media_url, dict(fetch_headers, Range="bytes=0-0"), None
+                )
+            ),
         ]
         assert headers == ranged_response_headers
 
@@ -379,15 +385,19 @@ async def test_fetch_headers() -> None:
         get_headers = dict(expected_response_headers)
         get_headers["Content-Length"] = "2"
         ahr_mock.side_effect = [
-            (405, expected_response_headers, ""),
-            (405, expected_response_headers, ""),
-            (200, get_headers, ""),
+            HttpResponse(405, expected_response_headers, ""),
+            HttpResponse(405, expected_response_headers, ""),
+            HttpResponse(200, get_headers, ""),
         ]
         headers = await profile._fetch_headers(media_url, fetch_headers)
         assert ahr_mock.await_args_list == [
-            mock.call("HEAD", media_url, fetch_headers),
-            mock.call("GET", media_url, dict(fetch_headers, Range="bytes=0-0")),
-            mock.call("GET", media_url, fetch_headers),
+            mock.call(HttpRequest("HEAD", media_url, fetch_headers, None)),
+            mock.call(
+                HttpRequest(
+                    "GET", media_url, dict(fetch_headers, Range="bytes=0-0"), None
+                )
+            ),
+            mock.call(HttpRequest("GET", media_url, fetch_headers, None)),
         ]
         assert headers == get_headers
 
@@ -396,12 +406,14 @@ async def test_fetch_headers() -> None:
         profile.profile_device.requester, "async_http_request"
     ) as ahr_mock:
         ahr_mock.side_effect = [
-            (404, expected_response_headers, ""),
-            (405, expected_response_headers, ""),
-            (200, expected_response_headers, ""),
+            HttpResponse(404, expected_response_headers, ""),
+            HttpResponse(405, expected_response_headers, ""),
+            HttpResponse(200, expected_response_headers, ""),
         ]
         headers = await profile._fetch_headers(media_url, fetch_headers)
-        ahr_mock.assert_called_once_with("HEAD", media_url, fetch_headers)
+        ahr_mock.assert_called_once_with(
+            HttpRequest("HEAD", media_url, fetch_headers, None)
+        )
         assert headers is None
 
     # Repeated server failures should give no headers
@@ -409,12 +421,16 @@ async def test_fetch_headers() -> None:
         profile.profile_device.requester, "async_http_request"
     ) as ahr_mock:
         # Different headers for working response, to check correct thing returned
-        ahr_mock.return_value = (500, {}, "")
+        ahr_mock.return_value = HttpResponse(500, {}, "")
         headers = await profile._fetch_headers(media_url, fetch_headers)
         assert ahr_mock.await_args_list == [
-            mock.call("HEAD", media_url, fetch_headers),
-            mock.call("GET", media_url, dict(fetch_headers, Range="bytes=0-0")),
-            mock.call("GET", media_url, fetch_headers),
+            mock.call(HttpRequest("HEAD", media_url, fetch_headers, None)),
+            mock.call(
+                HttpRequest(
+                    "GET", media_url, dict(fetch_headers, Range="bytes=0-0"), None
+                )
+            ),
+            mock.call(HttpRequest("GET", media_url, fetch_headers, None)),
         ]
         assert headers is None
 

--- a/tests/profiles/test_dlna_dms.py
+++ b/tests/profiles/test_dlna_dms.py
@@ -3,6 +3,7 @@
 import pytest
 
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.const import HttpResponse
 from async_upnp_client.exceptions import UpnpResponseError
 from async_upnp_client.profiles.dlna import DmsDevice
 
@@ -24,9 +25,11 @@ async def test_async_browse_metadata() -> None:
 
     # Object 0 is the root and must always exist
     requester.response_map[("POST", "http://dlna_dms:1234/upnp/control/ContentDir")] = (
-        200,
-        {},
-        read_file("dlna/dms/action_Browse_metadata_0.xml"),
+        HttpResponse(
+            200,
+            {},
+            read_file("dlna/dms/action_Browse_metadata_0.xml"),
+        )
     )
     metadata = await profile.async_browse_metadata("0")
     assert metadata.parent_id == "-1"
@@ -37,9 +40,11 @@ async def test_async_browse_metadata() -> None:
 
     # Object 2 will give some different results
     requester.response_map[("POST", "http://dlna_dms:1234/upnp/control/ContentDir")] = (
-        200,
-        {},
-        read_file("dlna/dms/action_Browse_metadata_2.xml"),
+        HttpResponse(
+            200,
+            {},
+            read_file("dlna/dms/action_Browse_metadata_2.xml"),
+        )
     )
     metadata = await profile.async_browse_metadata("2")
     assert metadata.parent_id == "0"
@@ -50,9 +55,11 @@ async def test_async_browse_metadata() -> None:
 
     # Object that is an item and not a container
     requester.response_map[("POST", "http://dlna_dms:1234/upnp/control/ContentDir")] = (
-        200,
-        {},
-        read_file("dlna/dms/action_Browse_metadata_item.xml"),
+        HttpResponse(
+            200,
+            {},
+            read_file("dlna/dms/action_Browse_metadata_item.xml"),
+        )
     )
     metadata = await profile.async_browse_metadata("1$6$35$1$1")
     assert metadata.parent_id == "1$6$35$1"
@@ -95,9 +102,11 @@ async def test_async_browse_children() -> None:
 
     # Object 0 is the root and must always exist
     requester.response_map[("POST", "http://dlna_dms:1234/upnp/control/ContentDir")] = (
-        200,
-        {},
-        read_file("dlna/dms/action_Browse_children_0.xml"),
+        HttpResponse(
+            200,
+            {},
+            read_file("dlna/dms/action_Browse_children_0.xml"),
+        )
     )
     result = await profile.async_browse_direct_children("0")
     assert result.number_returned == 4
@@ -120,9 +129,11 @@ async def test_async_browse_children() -> None:
 
     # Object 2 will give some different results
     requester.response_map[("POST", "http://dlna_dms:1234/upnp/control/ContentDir")] = (
-        200,
-        {},
-        read_file("dlna/dms/action_Browse_children_2.xml"),
+        HttpResponse(
+            200,
+            {},
+            read_file("dlna/dms/action_Browse_children_2.xml"),
+        )
     )
     result = await profile.async_browse_direct_children("2")
     assert result.number_returned == 3
@@ -142,9 +153,11 @@ async def test_async_browse_children() -> None:
 
     # Object that is an item and not a container
     requester.response_map[("POST", "http://dlna_dms:1234/upnp/control/ContentDir")] = (
-        200,
-        {},
-        read_file("dlna/dms/action_Browse_children_item.xml"),
+        HttpResponse(
+            200,
+            {},
+            read_file("dlna/dms/action_Browse_children_item.xml"),
+        )
     )
     result = await profile.async_browse_direct_children("1$6$35$1$1")
     assert result.number_returned == 0

--- a/tests/profiles/test_igd.py
+++ b/tests/profiles/test_igd.py
@@ -3,6 +3,7 @@
 import pytest
 
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.const import HttpResponse
 from async_upnp_client.profiles.igd import IgdDevice
 
 from ..conftest import RESPONSE_MAP, UpnpTestNotifyServer, UpnpTestRequester, read_file
@@ -27,7 +28,7 @@ async def test_init_igd_profile() -> None:
 async def test_get_total_bytes_received() -> None:
     """Test getting total bytes received."""
     responses = dict(RESPONSE_MAP)
-    responses[("POST", "http://igd:1234/WANCommonInterfaceConfig")] = (
+    responses[("POST", "http://igd:1234/WANCommonInterfaceConfig")] = HttpResponse(
         200,
         {},
         read_file("igd/action_WANCIC_GetTotalBytesReceived.xml"),
@@ -49,7 +50,7 @@ async def test_get_total_bytes_received() -> None:
 async def test_get_total_packets_received_empty_response() -> None:
     """Test getting total packets received with empty response, for broken (Draytek) device."""
     responses = dict(RESPONSE_MAP)
-    responses[("POST", "http://igd:1234/WANCommonInterfaceConfig")] = (
+    responses[("POST", "http://igd:1234/WANCommonInterfaceConfig")] = HttpResponse(
         200,
         {},
         read_file("igd/action_WANCIC_GetTotalPacketsReceived.xml"),
@@ -71,7 +72,7 @@ async def test_get_total_packets_received_empty_response() -> None:
 async def test_get_status_info_invalid_uptime() -> None:
     """Test getting status info with an invalid uptime response."""
     responses = dict(RESPONSE_MAP)
-    responses[("POST", "http://igd:1234/WANIPConnection")] = (
+    responses[("POST", "http://igd:1234/WANIPConnection")] = HttpResponse(
         200,
         {},
         read_file("igd/action_WANIPConnection_GetStatusInfoInvalidUptime.xml"),
@@ -98,7 +99,7 @@ async def test_negative_bytes_received_counter() -> None:
     which can result in negative values.
     """
     responses = dict(RESPONSE_MAP)
-    responses[("POST", "http://igd:1234/WANCommonInterfaceConfig")] = (
+    responses[("POST", "http://igd:1234/WANCommonInterfaceConfig")] = HttpResponse(
         200,
         {},
         read_file("igd/action_WANCIC_GetTotalBytesReceived_i4.xml"),

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -1,4 +1,5 @@
 """Unit tests for profile."""
+
 # pylint: disable=protected-access
 
 import asyncio
@@ -9,6 +10,7 @@ from unittest.mock import Mock
 import pytest
 
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.const import HttpResponse
 from async_upnp_client.exceptions import (
     UpnpActionResponseError,
     UpnpCommunicationError,
@@ -156,9 +158,14 @@ class TestUpnpProfileDevice:
         assert timeouts[2] == pytest.approx(now + 300, abs=1)
 
         # Tweak timeouts to check resubscription did something
+        entry = requester.response_map[
+            ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1")
+        ]
         requester.response_map[
             ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1")
-        ][1]["timeout"] = "Second-90"
+        ] = HttpResponse(
+            entry.status_code, {**entry.headers, "timeout": "Second-90"}, entry.body
+        )
 
         # Check subscriptions again, now timeouts should have changed
         timeout = await profile.async_subscribe_services(auto_resubscribe=False)
@@ -193,9 +200,19 @@ class TestUpnpProfileDevice:
 
         # Tweak timeouts to get a resubscription in a time suitable for testing.
         # Resubscription tolerance (60 seconds) + 1 second to get set up
+        entry = requester.response_map[
+            ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1")
+        ]
         requester.response_map[
             ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1")
-        ][1]["timeout"] = "Second-61"
+        ] = HttpResponse(
+            entry.status_code,
+            {
+                **entry.headers,
+                "timeout": "Second-61",
+            },
+            entry.body,
+        )
 
         # Test subscription
         timeout = await profile.async_subscribe_services(auto_resubscribe=True)
@@ -218,9 +235,19 @@ class TestUpnpProfileDevice:
         assert not profile._resubscriber_task.done()
 
         # Re-tweak timeouts to check resubscription did something
+        entry = requester.response_map[
+            ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/AVTransport1")
+        ]
         requester.response_map[
             ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/AVTransport1")
-        ][1]["timeout"] = "Second-90"
+        ] = HttpResponse(
+            entry.status_code,
+            {
+                **entry.headers,
+                "timeout": "Second-90",
+            },
+            entry.body,
+        )
 
         # Wait for an auto-resubscribe
         await asyncio.sleep(1.5)
@@ -317,9 +344,14 @@ class TestUpnpProfileDevice:
         profile.on_event = on_event_mock
 
         # Setup for auto-resubscription
+        entry = requester.response_map[
+            ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1")
+        ]
         requester.response_map[
             ("SUBSCRIBE", "http://dlna_dmr:1234/upnp/event/RenderingControl1")
-        ][1]["timeout"] = "Second-61"
+        ] = HttpResponse(
+            entry.status_code, {**entry.headers, "timeout": "Second-61"}, entry.body
+        )
         await profile.async_subscribe_services(auto_resubscribe=True)
 
         # Exception raised when trying to resubscribe and subsequent retry subscribe
@@ -364,7 +396,7 @@ class TestUpnpProfileDevice:
         requester = UpnpTestRequester(RESPONSE_MAP)
         requester.response_map[
             ("POST", "http://dlna_dmr:1234/upnp/control/AVTransport1")
-        ] = (200, {}, read_file("dlna/dmr/action_GetPositionInfo.xml"))
+        ] = HttpResponse(200, {}, read_file("dlna/dmr/action_GetPositionInfo.xml"))
 
         factory = UpnpFactory(requester)
         device = await factory.async_create_device("http://dlna_dmr:1234/device.xml")
@@ -425,7 +457,7 @@ class TestUpnpProfileDevice:
         requester = UpnpTestRequester(RESPONSE_MAP)
         requester.response_map[
             ("POST", "http://dlna_dmr:1234/upnp/control/AVTransport1")
-        ] = (200, {}, read_file("dlna/dmr/action_GetPositionInfo.xml"))
+        ] = HttpResponse(200, {}, read_file("dlna/dmr/action_GetPositionInfo.xml"))
 
         factory = UpnpFactory(requester)
         device = await factory.async_create_device("http://dlna_dmr:1234/device.xml")
@@ -484,7 +516,7 @@ class TestUpnpProfileDevice:
         # Good action response
         requester.response_map[
             ("POST", "http://dlna_dmr:1234/upnp/control/AVTransport1")
-        ] = (200, {}, read_file("dlna/dmr/action_GetPositionInfo.xml"))
+        ] = HttpResponse(200, {}, read_file("dlna/dmr/action_GetPositionInfo.xml"))
 
         factory = UpnpFactory(requester)
         device = await factory.async_create_device("http://dlna_dmr:1234/device.xml")

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,4 +1,5 @@
 """Unit tests for aiohttp."""
+
 # pylint: disable=protected-access
 
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ from async_upnp_client.aiohttp import (
     AiohttpRequester,
     _fixed_host_header,
 )
+from async_upnp_client.const import HttpRequest
 from async_upnp_client.exceptions import UpnpCommunicationError
 
 from .conftest import RESPONSE_MAP, UpnpTestRequester
@@ -62,5 +64,6 @@ async def test_server_init() -> None:
 async def test_client_decode_error(_mock_request: MagicMock) -> None:
     """Test handling unicode decode error."""
     requester = AiohttpRequester()
+    request = HttpRequest("GET", "http://192.168.1.1/desc.xml", {}, None)
     with pytest.raises(UpnpCommunicationError):
-        await requester.async_http_request("GET", "http://192.168.1.1/desc.xml")
+        await requester.async_http_request(request)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ import pytest
 
 from async_upnp_client.client import UpnpStateVariable
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.const import HttpResponse
 from async_upnp_client.exceptions import (
     UpnpActionError,
     UpnpActionErrorCode,
@@ -93,7 +94,7 @@ class TestUpnpStateVariable:
     async def test_init_bad_xml(self) -> None:
         """Test missing device element in device description."""
         responses = dict(RESPONSE_MAP)
-        responses[("GET", "http://dlna_dmr:1234/device.xml")] = (
+        responses[("GET", "http://dlna_dmr:1234/device.xml")] = HttpResponse(
             200,
             {},
             read_file("dlna/dmr/device_bad_namespace.xml"),
@@ -107,7 +108,7 @@ class TestUpnpStateVariable:
     async def test_empty_descriptor(self) -> None:
         """Test device with an empty descriptor file called in description.xml."""
         responses = dict(RESPONSE_MAP)
-        responses[("GET", "http://dlna_dmr:1234/device.xml")] = (
+        responses[("GET", "http://dlna_dmr:1234/device.xml")] = HttpResponse(
             200,
             {},
             read_file("dlna/dmr/device_with_empty_descriptor.xml"),
@@ -121,7 +122,7 @@ class TestUpnpStateVariable:
     async def test_empty_descriptor_non_strict(self) -> None:
         """Test device with an empty descriptor file called in description.xml."""
         responses = dict(RESPONSE_MAP)
-        responses[("GET", "http://dlna_dmr:1234/device.xml")] = (
+        responses[("GET", "http://dlna_dmr:1234/device.xml")] = HttpResponse(
             200,
             {},
             read_file("dlna/dmr/device_with_empty_descriptor.xml"),
@@ -314,9 +315,11 @@ class TestUpnpStateVariable:
         """Test state variable types i8 and ui8."""
         responses = dict(RESPONSE_MAP)
         responses[("GET", "http://dlna_dms:1234/ContentDirectory_1.xml")] = (
-            200,
-            {},
-            read_file("scpd_i8.xml"),
+            HttpResponse(
+                200,
+                {},
+                read_file("scpd_i8.xml"),
+            )
         )
         requester = UpnpTestRequester(responses)
         factory = UpnpFactory(requester)
@@ -377,11 +380,11 @@ class TestUpnpAction:
         action = service.action("SetVolume")
 
         service_type = "urn:schemas-upnp-org:service:RenderingControl:1"
-        _, _, body = action.create_request(
+        request = action.create_request(
             InstanceID=0, Channel="Master", DesiredVolume=10
         )
 
-        root = DET.fromstring(body)
+        root = DET.fromstring(request.body)
         namespace = {"rc_service": service_type}
         assert root.find(".//rc_service:SetVolume", namespace) is not None
         assert root.find(".//DesiredVolume", namespace) is not None
@@ -397,13 +400,13 @@ class TestUpnpAction:
 
         service_type = "urn:schemas-upnp-org:service:AVTransport:1"
         metadata = "<item>test thing</item>"
-        _, _, body = action.create_request(
+        request = action.create_request(
             InstanceID=0,
             CurrentURI="http://example.org/file.mp3",
             CurrentURIMetaData=metadata,
         )
 
-        root = DET.fromstring(body)
+        root = DET.fromstring(request.body)
         namespace = {"avt_service": service_type}
         assert root.find(".//avt_service:SetAVTransportURI", namespace) is not None
         assert root.find(".//CurrentURIMetaData", namespace) is not None
@@ -427,8 +430,9 @@ class TestUpnpAction:
         action = service.action("GetVolume")
 
         service_type = "urn:schemas-upnp-org:service:RenderingControl:1"
-        response = read_file("dlna/dmr/action_GetVolume.xml")
-        result = action.parse_response(service_type, {}, response)
+        response_body = read_file("dlna/dmr/action_GetVolume.xml")
+        response = HttpResponse(200, {}, response_body)
+        result = action.parse_response(service_type, response)
         assert result == {"CurrentVolume": 3}
 
     @pytest.mark.asyncio
@@ -441,8 +445,9 @@ class TestUpnpAction:
         action = service.action("SetVolume")
 
         service_type = "urn:schemas-upnp-org:service:RenderingControl:1"
-        response = read_file("dlna/dmr/action_SetVolume.xml")
-        result = action.parse_response(service_type, {}, response)
+        response_body = read_file("dlna/dmr/action_SetVolume.xml")
+        response = HttpResponse(200, {}, response_body)
+        result = action.parse_response(service_type, response)
         assert result == {}
 
     @pytest.mark.asyncio
@@ -455,9 +460,10 @@ class TestUpnpAction:
         action = service.action("GetVolume")
 
         service_type = "urn:schemas-upnp-org:service:RenderingControl:1"
-        response = read_file("dlna/dmr/action_GetVolumeError.xml")
+        response_body = read_file("dlna/dmr/action_GetVolumeError.xml")
+        response = HttpResponse(200, {}, response_body)
         with pytest.raises(UpnpActionError) as exc:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
         assert exc.value.error_code == UpnpActionErrorCode.INVALID_ARGS
         assert exc.value.error_desc == "Invalid Args"
 
@@ -471,8 +477,9 @@ class TestUpnpAction:
         action = service.action("GetMediaInfo")
 
         service_type = "urn:schemas-upnp-org:service:AVTransport:1"
-        response = read_file("dlna/dmr/action_GetMediaInfo.xml")
-        result = action.parse_response(service_type, {}, response)
+        response_body = read_file("dlna/dmr/action_GetMediaInfo.xml")
+        response = HttpResponse(200, {}, response_body)
+        result = action.parse_response(service_type, response)
         assert result == {
             "CurrentURI": "uri://1.mp3",
             "CurrentURIMetaData": "<DIDL-Lite "
@@ -505,9 +512,10 @@ class TestUpnpAction:
         action = service.action("GetVolume")
 
         service_type = "urn:schemas-upnp-org:service:RenderingControl:1"
-        response = read_file("dlna/dmr/action_GetVolumeInvalidServiceType.xml")
+        response_body = read_file("dlna/dmr/action_GetVolumeInvalidServiceType.xml")
+        response = HttpResponse(200, {}, response_body)
         try:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
             assert False
         except UpnpError:
             pass
@@ -522,9 +530,12 @@ class TestUpnpAction:
         action = service.action("GetTransportInfo")
 
         service_type = "urn:schemas-upnp-org:service:AVTransport:1"
-        response = read_file("dlna/dmr/action_GetTransportInfoInvalidServiceType.xml")
+        response_body = read_file(
+            "dlna/dmr/action_GetTransportInfoInvalidServiceType.xml"
+        )
+        response = HttpResponse(200, {}, response_body)
         try:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
             assert False
         except UpnpError:
             pass
@@ -542,9 +553,10 @@ class TestUpnpAction:
         service = device.service(service_type)
         action = service.action(test_action)
 
-        response = read_file("dlna/dmr/action_GetVolumeExtraOutParameter.xml")
+        response_body = read_file("dlna/dmr/action_GetVolumeExtraOutParameter.xml")
+        response = HttpResponse(200, {}, response_body)
         try:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
             assert False
         except UpnpError:
             pass
@@ -555,7 +567,7 @@ class TestUpnpAction:
         action = service.action(test_action)
 
         try:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
         except UpnpError:
             assert False
 
@@ -574,9 +586,10 @@ class TestUpnpAction:
         assert service is not None
         action = service.action(test_action)
 
-        response = read_file("igd/action_WANPIPConnection_DeletePortMapping.xml")
+        response_body = read_file("igd/action_WANPIPConnection_DeletePortMapping.xml")
+        response = HttpResponse(200, {}, response_body)
         try:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
             assert False
         except UpnpError:
             pass
@@ -589,7 +602,7 @@ class TestUpnpAction:
         action = service.action(test_action)
 
         try:
-            action.parse_response(service_type, {}, response)
+            action.parse_response(service_type, response)
         except UpnpError:
             assert False
 
@@ -725,9 +738,11 @@ class TestUpnpService:
         """Test handling of bad service descriptions in strict mode."""
         responses = dict(RESPONSE_MAP)
         responses[("GET", "http://dlna_dmr:1234/RenderingControl_1.xml")] = (
-            200,
-            {},
-            read_file(rc_doc),
+            HttpResponse(
+                200,
+                {},
+                read_file(rc_doc),
+            )
         )
         requester = UpnpTestRequester(responses)
         factory = UpnpFactory(requester)
@@ -747,9 +762,11 @@ class TestUpnpService:
         """Test bad SCPD in non-strict mode."""
         responses = dict(RESPONSE_MAP)
         responses[("GET", "http://dlna_dmr:1234/RenderingControl_1.xml")] = (
-            200,
-            {},
-            read_file(rc_doc),
+            HttpResponse(
+                200,
+                {},
+                read_file(rc_doc),
+            )
         )
         requester = UpnpTestRequester(responses)
         factory = UpnpFactory(requester, non_strict=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -643,7 +643,10 @@ class TestUpnpService:
     async def test_call_action(self) -> None:
         """Test calling a UpnpAction."""
         responses: MutableMapping = {
-            ("POST", "http://dlna_dmr:1234/upnp/control/RenderingControl1"): (
+            (
+                "POST",
+                "http://dlna_dmr:1234/upnp/control/RenderingControl1",
+            ): HttpResponse(
                 200,
                 {},
                 read_file("dlna/dmr/action_GetVolume.xml"),
@@ -663,7 +666,10 @@ class TestUpnpService:
     async def test_soap_fault_http_error(self) -> None:
         """Test an action response with HTTP error and SOAP fault raises exception."""
         responses: MutableMapping = {
-            ("POST", "http://dlna_dmr:1234/upnp/control/RenderingControl1"): (
+            (
+                "POST",
+                "http://dlna_dmr:1234/upnp/control/RenderingControl1",
+            ): HttpResponse(
                 500,
                 {},
                 read_file("dlna/dmr/action_GetVolumeError.xml"),
@@ -686,7 +692,10 @@ class TestUpnpService:
     async def test_http_error(self) -> None:
         """Test an action response with HTTP error and blank body raises exception."""
         responses: MutableMapping = {
-            ("POST", "http://dlna_dmr:1234/upnp/control/RenderingControl1"): (
+            (
+                "POST",
+                "http://dlna_dmr:1234/upnp/control/RenderingControl1",
+            ): HttpResponse(
                 500,
                 {},
                 "",
@@ -707,7 +716,10 @@ class TestUpnpService:
     async def test_soap_fault_http_ok(self) -> None:
         """Test an action response with HTTP OK but SOAP fault raises exception."""
         responses: MutableMapping = {
-            ("POST", "http://dlna_dmr:1234/upnp/control/RenderingControl1"): (
+            (
+                "POST",
+                "http://dlna_dmr:1234/upnp/control/RenderingControl1",
+            ): HttpResponse(
                 200,
                 {},
                 read_file("dlna/dmr/action_GetVolumeError.xml"),

--- a/tests/test_description_cache.py
+++ b/tests/test_description_cache.py
@@ -7,6 +7,7 @@ import aiohttp
 import defusedxml.ElementTree as DET
 import pytest
 
+from async_upnp_client.const import HttpResponse
 from async_upnp_client.description_cache import DescriptionCache
 
 from .conftest import UpnpTestRequester
@@ -22,7 +23,7 @@ async def test_fetch_parse_success() -> None:
   </device>
 </root>"""
     requester = UpnpTestRequester(
-        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+        {("GET", "http://192.168.1.1/desc.xml"): HttpResponse(200, {}, xml)}
     )
     description_cache = DescriptionCache(requester)
     descr_xml = await description_cache.async_get_description_xml(
@@ -50,7 +51,7 @@ async def test_fetch_parse_success_invalid_chars() -> None:
   </device>
 </root>"""
     requester = UpnpTestRequester(
-        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+        {("GET", "http://192.168.1.1/desc.xml"): HttpResponse(200, {}, xml)}
     )
     description_cache = DescriptionCache(requester)
     descr_xml = await description_cache.async_get_description_xml(
@@ -74,7 +75,7 @@ async def test_fetch_fail(exc: Exception) -> None:
     """Test fail fetching a description."""
     xml = ""
     requester = UpnpTestRequester(
-        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+        {("GET", "http://192.168.1.1/desc.xml"): HttpResponse(200, {}, xml)}
     )
     requester.exceptions.append(exc)
     description_cache = DescriptionCache(requester)
@@ -94,7 +95,7 @@ async def test_parsing_fail_invalid_xml() -> None:
     """Test fail parsing a description with invalid XML."""
     xml = """<root xmlns="urn:schemas-upnp-org:device-1-0">INVALIDXML"""
     requester = UpnpTestRequester(
-        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+        {("GET", "http://192.168.1.1/desc.xml"): HttpResponse(200, {}, xml)}
     )
     description_cache = DescriptionCache(requester)
     descr_xml = await description_cache.async_get_description_xml(
@@ -113,7 +114,7 @@ async def test_parsing_fail_error() -> None:
     """Test fail parsing a description with invalid XML."""
     xml = ""
     requester = UpnpTestRequester(
-        {("GET", "http://192.168.1.1/desc.xml"): (200, {}, xml)}
+        {("GET", "http://192.168.1.1/desc.xml"): HttpResponse(200, {}, xml)}
     )
     description_cache = DescriptionCache(requester)
     descr_xml = await description_cache.async_get_description_xml(

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -9,6 +9,7 @@ import pytest
 
 from async_upnp_client.client import UpnpService, UpnpStateVariable
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.const import HttpRequest
 from async_upnp_client.event_handler import UpnpEventHandlerRegister
 
 from .conftest import RESPONSE_MAP, UpnpTestNotifyServer, UpnpTestRequester
@@ -124,7 +125,10 @@ async def test_on_notify_upnp_event() -> None:
 </e:propertyset>
 """
 
-    result = await event_handler.handle_notify(headers, body)
+    http_request = HttpRequest(
+        "NOTIFY", "http://dlna_dmr:1234/upnp/event/RenderingControl1", headers, body
+    )
+    result = await event_handler.handle_notify(http_request)
     assert result == 200
 
     assert len(changed_vars) == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 """Test server functionality."""
+
 import asyncio
 import socket
 import xml.etree.ElementTree as ET
@@ -227,9 +228,9 @@ async def test_init(upnp_server: Any) -> None:
     """Test device query."""
     # pylint: disable=redefined-outer-name
     http_client = upnp_server.http_client
-    resp = await http_client.get("/device.xml")
-    assert resp.status == 200
-    data = await resp.text()
+    response = await http_client.get("/device.xml")
+    assert response.status == 200
+    data = await response.text()
     assert data == read_file("server/device.xml").strip()
 
 
@@ -238,7 +239,7 @@ async def test_action(upnp_server: Any) -> None:
     """Test action execution."""
     # pylint: disable=redefined-outer-name
     http_client = upnp_server.http_client
-    resp = await http_client.post(
+    response = await http_client.post(
         "/upnp/control/TestServerService",
         data=read_file("server/action_request.xml"),
         headers={
@@ -247,14 +248,14 @@ async def test_action(upnp_server: Any) -> None:
             "soapaction": "urn:schemas-upnp-org:service:TestServerService:1#SetValues",
         },
     )
-    assert resp.status == 200
-    data = await resp.text()
+    assert response.status == 200
+    data = await response.text()
     assert data == read_file("server/action_response.xml").strip()
 
 
 @pytest.mark.asyncio
 async def test_subscribe(upnp_server: Any) -> None:
-    """Test subcsription to server event."""
+    """Test subscription to server event."""
     # pylint: disable=redefined-outer-name
     event = asyncio.Event()
     expect = 0
@@ -272,19 +273,21 @@ async def test_subscribe(upnp_server: Any) -> None:
 
     http_client = upnp_server.http_client
     callback = upnp_server.callback
-    service = upnp_server.server._device.service(  # pylint: disable=protected-access
-        "urn:schemas-upnp-org:service:TestServerService:1"
+    service: ServerServiceTest = (
+        upnp_server.server._device.service(  # pylint: disable=protected-access
+            "urn:schemas-upnp-org:service:TestServerService:1"
+        )
     )
     callback.set_callback(on_callback)
-    resp = await http_client.request(
+    response = await http_client.request(
         "SUBSCRIBE",
         "/upnp/event/TestServerService",
         headers={"CALLBACK": "</foo/bar>", "NT": "upnp:event", "TIMEOUT": "Second-30"},
     )
-    assert resp.status == 200
-    data = await resp.text()
+    assert response.status == 200
+    data = await response.text()
     assert not data
-    sid = resp.headers.get("SID")
+    sid = response.headers.get("SID")
     assert sid
     with suppress(asyncio.TimeoutError):
         await asyncio.wait_for(event.wait(), 2)


### PR DESCRIPTION
Add pre-/post-hooks when doing/handling HTTP requests. Includes refactoring of `Tuple`s to `HttpRequest`/`HttpResponse`.

Refs #228