### PR TITLE
Fix media_image_url using Resource.url instead of .uri

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   - push
+  - pull_request
 
 env:
   publish-python-version: 3.12

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -1208,8 +1208,8 @@ class DmrDevice(ConnectionManagerMixin, UpnpProfileDevice):
 
             for res in item.resources:
                 protocol_info = res.protocol_info or ""
-                if protocol_info.startswith("http-get:*:image/"):
-                    return absolute_url(device_url, res.url)
+                if protocol_info.startswith("http-get:*:image/") and res.uri:
+                    return absolute_url(device_url, res.uri)
 
         return None
 

--- a/changes/244.bugfix
+++ b/changes/244.bugfix
@@ -1,0 +1,1 @@
+Fix media_image_url using Resource.url instead of .uri (@chishm)


### PR DESCRIPTION
This is a fix for Home Assistant issues [111078](https://github.com/home-assistant/core/issues/111078) and [125616](https://github.com/home-assistant/core/issues/125616). The `DmrDevice.media_image_url` method was trying to use `Resource.url`, when it should be `Resource.uri`.