### PR TITLE
Make `async_call_action` signature accept string parameter

### DIFF
--- a/async_upnp_client/client.py
+++ b/async_upnp_client/client.py
@@ -21,6 +21,7 @@ from typing import (
     Set,
     Type,
     TypeVar,
+    Union,
 )
 from xml.etree import ElementTree as ET
 from xml.parsers import expat
@@ -508,7 +509,7 @@ class UpnpService:
         return self.actions[name]
 
     async def async_call_action(
-        self, action: "UpnpAction", **kwargs: Any
+        self, action: Union["UpnpAction", str], **kwargs: Any
     ) -> Mapping[str, Any]:
         """
         Call a UpnpAction.

--- a/changes/246.bugfix
+++ b/changes/246.bugfix
@@ -1,0 +1,1 @@
+Make async_call_action signature accept string parameter.

--- a/changes/246.bugfix.rst
+++ b/changes/246.bugfix.rst
@@ -1,0 +1,1 @@
+Make async_call_action signature accept string parameter.

--- a/changes/246.bugfix.rst
+++ b/changes/246.bugfix.rst
@@ -1,1 +1,0 @@
-Make async_call_action signature accept string parameter.


### PR DESCRIPTION
The first line of `async_call_action` checks whether the `action` argument is a string, so it makes sense for the function signature to accept an `action` of type `str`.

I've used `Union` instead of `|` in order to support Python versions < 3.10, which this library currently stops.