### PR TITLE
Use transport for sending responses instead of a blocking socket

### DIFF
--- a/async_upnp_client/server.py
+++ b/async_upnp_client/server.py
@@ -470,8 +470,13 @@ class SsdpSearchResponder:
         self.options = options or {}
 
         self._transport: Optional[DatagramTransport] = None
-        self._response_socket: Optional[socket.socket] = None
+        self._response_transport: Optional[DatagramTransport] = None
         self._loop = loop or asyncio.get_running_loop()
+
+    def _on_connect_response(self, transport: DatagramTransport) -> None:
+        """Handle on connect for response."""
+        _LOGGER.debug("Connected to response transport: %s", transport)
+        self._response_transport = transport
 
     def _on_connect(self, transport: DatagramTransport) -> None:
         """Handle on connect."""
@@ -492,7 +497,7 @@ class SsdpSearchResponder:
         ):
             return
 
-        remote_addr = headers.get_lower("_remote_addr")
+        remote_addr = cast(AddressTupleVXType, headers.get_lower("_remote_addr"))
         debug = _LOGGER.isEnabledFor(logging.DEBUG)
         if debug:  # pragma: no branch
             _LOGGER.debug(
@@ -616,20 +621,24 @@ class SsdpSearchResponder:
         """Start."""
         _LOGGER.debug("Start listening for search requests")
 
-        # Create response socket.
-        self._response_socket, _source, _target = get_ssdp_socket(
-            self.source, self.target
+        # Create response socket/protocol.
+        response_sock, _source, _target = get_ssdp_socket(self.source, self.target)
+
+        await self._loop.create_datagram_endpoint(
+            lambda: SsdpProtocol(
+                self._loop,
+                on_connect=self._on_connect_response,
+            ),
+            sock=response_sock,
         )
 
-        # Construct a socket for use with this pair of endpoints.
+        # Create listening socket/protocol.
         sock, _source, _target = get_ssdp_socket(self.source, self.target)
 
-        # Bind to address.
         address = ("", self.target[1])
         _LOGGER.debug("Binding socket, socket: %s, address: %s", sock, address)
         sock.bind(address)
 
-        # Create protocol and send discovery packet.
         await self._loop.create_datagram_endpoint(
             lambda: SsdpProtocol(
                 self._loop,
@@ -695,22 +704,28 @@ class SsdpSearchResponder:
             },
         )
 
-    def _send_responses(self, remote_addr: str, responses: List[bytes]) -> None:
+    def _send_responses(
+        self, remote_addr: AddressTupleVXType, responses: List[bytes]
+    ) -> None:
         """Send responses."""
+        assert self._response_transport
         if _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: no branch
+            sock: Optional[socket.socket] = self._response_transport.get_extra_info(
+                "socket"
+            )
             _LOGGER.debug(
                 "Sending SSDP packet, transport: %s, socket: %s, target: %s",
-                None,
-                self._response_socket,
+                self._response_transport,
+                sock,
                 remote_addr,
             )
         _LOGGER_TRAFFIC_SSDP.debug(
             "Sending SSDP packets, target: %s, data: %s", remote_addr, responses
         )
-        assert self._response_socket, "Socket not initialized"
         for response in responses:
             try:
-                self._response_socket.sendto(response, remote_addr)
+                protocol = cast(SsdpProtocol, self._response_transport.get_protocol())
+                protocol.send_ssdp_packet(response, remote_addr)
             except OSError as err:
                 _LOGGER.debug("Error sending response: %s", err)
 

--- a/changes/263.feature
+++ b/changes/263.feature
@@ -1,0 +1,1 @@
+Use transport for sending responses instead of a blocking socket.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -320,15 +320,14 @@ async def test_subscribe(upnp_server: UpnpServerTuple) -> None:
 
 def test_send_search_response_ok(upnp_server: UpnpServerTuple) -> None:
     """Test sending search response without any failure."""
-    # pylint: disable=redefined-outer-name
+    # pylint: disable=redefined-outer-name, protected-access
     server = upnp_server.server
-    search_responser = server._search_responder  # pylint: disable=protected-access
+    search_responser = server._search_responder
     assert search_responser
-    response_socket = cast(
-        Mock, search_responser._response_socket  # pylint: disable=protected-access
-    )
-    assert response_socket
-    response_socket.sendto = Mock(side_effect=None)
+    assert search_responser._response_transport
+    response_transport = cast(Mock, search_responser._response_transport)
+    assert response_transport
+    response_transport.sendto = Mock(side_effect=None)
 
     headers = CaseInsensitiveDict(
         {
@@ -338,24 +337,21 @@ def test_send_search_response_ok(upnp_server: UpnpServerTuple) -> None:
             "_remote_addr": ("192.168.1.101", 31234),
         }
     )
-    search_responser._on_data(  # pylint: disable=protected-access
-        "M-SEARCH * HTTP/1.1", headers
-    )
+    search_responser._on_data("M-SEARCH * HTTP/1.1", headers)
 
-    response_socket.sendto.assert_called()
+    response_transport.sendto.assert_called()
 
 
 def test_send_search_response_oserror(upnp_server: UpnpServerTuple) -> None:
     """Test sending search response and failing, but the error is handled."""
-    # pylint: disable=redefined-outer-name
+    # pylint: disable=redefined-outer-name, protected-access
     server = upnp_server.server
-    search_responser = server._search_responder  # pylint: disable=protected-access
+    search_responser = server._search_responder
     assert search_responser
-    response_socket = cast(
-        Mock, search_responser._response_socket  # pylint: disable=protected-access
-    )
-    assert response_socket
-    response_socket.sendto = Mock(side_effect=OSError)
+    assert search_responser._response_transport
+    response_transport = cast(Mock, search_responser._response_transport)
+    assert response_transport
+    response_transport.sendto = Mock(side_effect=None)
 
     headers = CaseInsensitiveDict(
         {
@@ -365,8 +361,6 @@ def test_send_search_response_oserror(upnp_server: UpnpServerTuple) -> None:
             "_remote_addr": ("192.168.1.101", 31234),
         }
     )
-    search_responser._on_data(  # pylint: disable=protected-access
-        "M-SEARCH * HTTP/1.1", headers
-    )
+    search_responser._on_data("M-SEARCH * HTTP/1.1", headers)
 
-    response_socket.sendto.assert_called()
+    response_transport.sendto.assert_called()


### PR DESCRIPTION
Use transport for sending responses instead of a blocking socket

Fixes #260