### PR TITLE
Modernize packaging

### DIFF
--- a/changes/267.misc.1
+++ b/changes/267.misc.1
@@ -1,0 +1,1 @@
+Move project metadata to ``pyproject.toml``.

--- a/changes/267.misc.2
+++ b/changes/267.misc.2
@@ -1,0 +1,1 @@
+Use correct SPDX license identifier for project metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=77.0"]
+
+[project]
+name = "async_upnp_client"
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
+description = "Async UPnP Client"
+readme = "README.rst"
+authors = [{ name = "Steven Looman", email = "steven.looman@gmail.com" }]
+keywords = [
+  "ssdp",
+  "Simple Service Discovery Protocol",
+  "upnp",
+  "Universal Plug and Play",
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Framework :: AsyncIO",
+  "Operating System :: POSIX",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: Microsoft :: Windows",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+requires-python = ">=3.9"
+dependencies = [
+  "aiohttp>3.9.0,<4.0",
+  "async-timeout>=3.0,<6.0",
+  "defusedxml>=0.6.0",
+  "python-didl-lite~=1.4.0",
+  "voluptuous>=0.15.2",
+]
+dynamic = ["version"]
+
+[project.urls]
+"GitHub: repo" = "https://github.com/StevenLooman/async_upnp_client"
+
+[project.scripts]
+upnp-client = "async_upnp_client.cli:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "async_upnp_client.__version__" }
+
+[tool.setuptools.packages.find]
+include = ["async_upnp_client*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,72 +8,11 @@ tag_name = {new_version}
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[metadata]
-name = async_upnp_client
-version = attr: async_upnp_client.__version__
-description = Async UPnP Client
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-url = https://github.com/StevenLooman/async_upnp_client
-project_urls = 
-	GitHub: repo = https://github.com/StevenLooman/async_upnp_client
-author = Steven Looman
-author_email = steven.looman@gmail.com
-license = Apache 2
-license_file = LICENSE.txt
-classifiers = 
-	Development Status :: 5 - Production/Stable
-	Intended Audience :: Developers
-	License :: OSI Approved :: Apache Software License
-	Framework :: AsyncIO
-	Operating System :: POSIX
-	Operating System :: MacOS :: MacOS X
-	Operating System :: Microsoft :: Windows
-	Programming Language :: Python :: 3.9
-	Programming Language :: Python :: 3.10
-	Programming Language :: Python :: 3.11
-	Programming Language :: Python :: 3.12
-	Programming Language :: Python :: 3.13
-keywords = 
-	ssdp
-	Simple Service Discovery Protocol
-	upnp
-	Universal Plug and Play
-
-[options]
-python_requires = >=3.9
-install_requires = 
-	voluptuous >= 0.15.2
-	aiohttp >3.9.0, <4.0
-	async-timeout >=3.0, <6.0
-	python-didl-lite ~= 1.4.0
-	defusedxml >= 0.6.0
-tests_require = 
-	pytest ~= 8.3.3
-	pytest-asyncio >= 0.24,< 0.27
-	pytest-aiohttp >= 1.0.5,< 1.2.0
-	pytest-cov >= 5.0,< 6.2
-	coverage >= 7.6.1,< 7.9.0
-	asyncmock ~= 0.4.2
-packages = 
-	async_upnp_client
-	async_upnp_client.profiles
-
-[options.entry_points]
-console_scripts = 
-	upnp-client = async_upnp_client.cli:main
-
-[options.package_data]
-async-upnp-client = py.typed
-
-[bdist_wheel]
-python-tag = py3
-
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 max-line-length = 119
 max-complexity = 25
-ignore = 
+ignore =
 	E501,
 	W503,
 	E203,
@@ -106,6 +45,6 @@ min-similarity-lines = 8
 
 [coverage:run]
 source = async_upnp_client
-omit = 
+omit =
 	async_upnp_client/aiohttp.py
 	async_upnp_client/cli.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""Setup."""
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
- Move project metadata to `pyproject.toml`
- Use correct SPDX license identifier: `Apache-2.0`
- Remove `tests_require`. AFAIK setuptools doesn't really support this anymore. Furthermore the test requirements are also present in `tox.ini`.

Metadata diff
```diff
 ...
-Author: Steven Looman
-Author-email: steven.looman@gmail.com
+Author-email: Steven Looman <steven.looman@gmail.com>
-License: Apache 2
+License-Expression: Apache-2.0
-Home-page: https://github.com/StevenLooman/async_upnp_client
 Project-URL: GitHub: repo, https://github.com/StevenLooman/async_upnp_client
 ...
```