### PR TITLE
Add localhost hostname to invalid locations

### DIFF
--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -43,12 +43,18 @@ IGNORED_HEADERS = {
     "location",  # Location-header is handled differently!
 }
 
+_INVALID_LOCATIONS = (
+    "://127.0.0.1",
+    "://[::1]",
+    "://169.254",
+    "://localhost",
+)
 
 @lru_cache(maxsize=128)
 def is_valid_location(location: str) -> bool:
     """Validate if this location is usable."""
-    return location.startswith("http") and not (
-        "://127.0.0.1" in location or "://[::1]" in location or "://169.254" in location
+    return location.startswith("http") and not any(
+        invalid in location for invalid in _INVALID_LOCATIONS
     )
 
 

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -44,7 +44,7 @@ IGNORED_HEADERS = {
 }
 
 _INVALID_LOCATIONS = (
-    "://127.0.0.",
+    "://127.",
     "://[::1]",
     "://169.254",
     "://localhost",

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -50,6 +50,7 @@ _INVALID_LOCATIONS = (
     "://localhost",
 )
 
+
 @lru_cache(maxsize=128)
 def is_valid_location(location: str) -> bool:
     """Validate if this location is usable."""

--- a/async_upnp_client/ssdp_listener.py
+++ b/async_upnp_client/ssdp_listener.py
@@ -44,7 +44,7 @@ IGNORED_HEADERS = {
 }
 
 _INVALID_LOCATIONS = (
-    "://127.0.0.1",
+    "://127.0.0.",
     "://[::1]",
     "://169.254",
     "://localhost",

--- a/changes/283.bugfix
+++ b/changes/283.bugfix
@@ -1,0 +1,1 @@
+Add localhost hostname to invalid locations

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -586,6 +586,7 @@ async def test_see_search_invalid_location() -> None:
         "http://127.0.0.1:1234/device.xml",
         "http://[::1]:1234/device.xml",
         "http://169.254.12.1:1234/device.xml",
+        "http://localhost:1234/device.xml",
     ],
 )
 async def test_see_search_localhost_location(location: str) -> None:

--- a/tests/test_ssdp_listener.py
+++ b/tests/test_ssdp_listener.py
@@ -584,6 +584,7 @@ async def test_see_search_invalid_location() -> None:
     "location",
     [
         "http://127.0.0.1:1234/device.xml",
+        "http://127.0.0.20:1234/device.xml",
         "http://[::1]:1234/device.xml",
         "http://169.254.12.1:1234/device.xml",
         "http://localhost:1234/device.xml",


### PR DESCRIPTION
The hostname `localhost` should also be an invalid source like `127.0.0.1`.
Before this PR, `localhost` was counted asa  valid source, but we should ignore it the same as the equivalent IP `127.0.0.1`