### PR TITLE
Fix: Handle missing 'song' namespace in DLNA metadata

### DIFF
--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -1436,8 +1436,15 @@ class DmsDevice(ConnectionManagerMixin, UpnpProfileDevice):
             SortCriteria=sort_criteria,
         )
 
+        xml_result = result["Result"]
+        if '<song:' in xml_result and 'xmlns:song=' not in xml_result:
+            xml_result = xml_result.replace(
+                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/">',
+                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/" xmlns:song="www.wiimu.com/song/">'
+            )
+        
         return DmsDevice.BrowseResult(
-            didl_lite.from_xml_string(result["Result"], strict=False),
+            didl_lite.from_xml_string(xml_result, strict=False),
             int(result["NumberReturned"]),
             int(result["TotalMatches"]),
             int(result["UpdateID"]),
@@ -1527,8 +1534,15 @@ class DmsDevice(ConnectionManagerMixin, UpnpProfileDevice):
             SortCriteria=sort_criteria,
         )
 
+        xml_result = result["Result"]
+        if '<song:' in xml_result and 'xmlns:song=' not in xml_result:
+            xml_result = xml_result.replace(
+                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/">',
+                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/" xmlns:song="www.wiimu.com/song/">'
+            )
+         
         browse_result = DmsDevice.BrowseResult(
-            didl_lite.from_xml_string(result["Result"], strict=False),
+            didl_lite.from_xml_string(xml_result, strict=False),
             int(result["NumberReturned"]),
             int(result["TotalMatches"]),
             int(result["UpdateID"]),

--- a/async_upnp_client/profiles/dlna.py
+++ b/async_upnp_client/profiles/dlna.py
@@ -224,6 +224,13 @@ def _lower_split_commas(input_: str) -> set[str]:
 def _cached_from_xml_string(
     xml: str,
 ) -> list[didl_lite.DidlObject | didl_lite.Descriptor]:
+    # --- YAMA BURAYA ---
+    if xml and '<song:' in xml and 'xmlns:song=' not in xml:
+        xml = xml.replace(
+            'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/">',
+            'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/" xmlns:song="www.wiimu.com/song/">'
+        )
+    # -------------------
     return didl_lite.from_xml_string(xml, strict=False)
 
 
@@ -1436,15 +1443,8 @@ class DmsDevice(ConnectionManagerMixin, UpnpProfileDevice):
             SortCriteria=sort_criteria,
         )
 
-        xml_result = result["Result"]
-        if '<song:' in xml_result and 'xmlns:song=' not in xml_result:
-            xml_result = xml_result.replace(
-                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/">',
-                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/" xmlns:song="www.wiimu.com/song/">'
-            )
-        
         return DmsDevice.BrowseResult(
-            didl_lite.from_xml_string(xml_result, strict=False),
+            didl_lite.from_xml_string(result["Result"], strict=False),
             int(result["NumberReturned"]),
             int(result["TotalMatches"]),
             int(result["UpdateID"]),
@@ -1534,15 +1534,8 @@ class DmsDevice(ConnectionManagerMixin, UpnpProfileDevice):
             SortCriteria=sort_criteria,
         )
 
-        xml_result = result["Result"]
-        if '<song:' in xml_result and 'xmlns:song=' not in xml_result:
-            xml_result = xml_result.replace(
-                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/">',
-                'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/" xmlns:song="www.wiimu.com/song/">'
-            )
-         
         browse_result = DmsDevice.BrowseResult(
-            didl_lite.from_xml_string(xml_result, strict=False),
+            didl_lite.from_xml_string(result["Result"], strict=False),
             int(result["NumberReturned"]),
             int(result["TotalMatches"]),
             int(result["UpdateID"]),


### PR DESCRIPTION
Some DLNA devices (like JBL) return metadata with a song: prefix but fail to declare the namespace in the XML. This patch adds the missing namespace to prevent XML parsing errors. discussed issue is here: 
[https://github.com/music-assistant/support/issues/4398](https://github.com/music-assistant/support/issues/4398)