### PR TITLE
Fix SSRF false positive on IPv6 link-local addresses with zone IDs

### DIFF
--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -45,6 +45,20 @@ from async_upnp_client.utils import absolute_url
 _LOGGER = logging.getLogger(__name__)
 
 
+def _strip_ipv6_zone_id(hostname: str | None) -> str | None:
+    """Strip the zone ID from an IPv6 hostname for identity comparison.
+
+    Link-local IPv6 addresses may carry a zone ID (e.g. fe80::1%2) that
+    identifies the local network interface. The zone ID is irrelevant for
+    host identity and is often present in the device description URL
+    (added during SSDP discovery) but absent from absolute service URLs
+    in the device XML.
+    """
+    if hostname is None:
+        return None
+    return hostname.split("%")[0]
+
+
 class UpnpFactory:
     """
     Factory for UpnpService and friends.
@@ -197,7 +211,7 @@ class UpnpFactory:
         potential SSRF vector (e.g. cloud-metadata or loopback endpoints) and is
         refused in strict mode or skipped (with a warning) in non-strict mode.
         """
-        base_host = urllib.parse.urlparse(base_url).hostname
+        base_host = _strip_ipv6_zone_id(urllib.parse.urlparse(base_url).hostname)
         for tag in ("SCPDURL", "controlURL", "eventSubURL"):
             ref = service_description_el.findtext(f"device:{tag}", "", NS)
             if not ref:
@@ -206,7 +220,7 @@ class UpnpFactory:
             # urlparse raise; fail closed and treat it as a refused host.
             try:
                 resolved = urllib.parse.urljoin(base_url, ref)
-                resolved_host = urllib.parse.urlparse(resolved).hostname
+                resolved_host = _strip_ipv6_zone_id(urllib.parse.urlparse(resolved).hostname)
             except ValueError:
                 resolved_host = None
             if resolved_host != base_host:

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -45,18 +45,35 @@ from async_upnp_client.utils import absolute_url
 _LOGGER = logging.getLogger(__name__)
 
 
-def _strip_ipv6_zone_id(hostname: str | None) -> str | None:
-    """Strip the zone ID from an IPv6 hostname for identity comparison.
+def _ipv6_hosts_match(base_host: str | None, resolved_host: str | None) -> bool:
+    """Check whether two hostnames refer to the same IPv6 address.
 
-    Link-local IPv6 addresses may carry a zone ID (e.g. fe80::1%2) that
-    identifies the local network interface. The zone ID is irrelevant for
-    host identity and is often present in the device description URL
-    (added during SSDP discovery) but absent from absolute service URLs
-    in the device XML.
+    SSDP discovery adds zone IDs to link-local device URLs (e.g. fe80::1%2),
+    but devices omit them from absolute service URLs in their XML. A plain
+    string comparison rejects these as different hosts. This function handles
+    the mismatch: if only one side carries a zone ID, compare the bare
+    addresses. If both carry zone IDs, require them to match. Non-IPv6
+    hostnames are not touched (returns False so the caller falls through
+    to normal comparison).
     """
-    if hostname is None:
-        return None
-    return hostname.split("%")[0]
+    if base_host is None or resolved_host is None:
+        return False
+    if ":" not in base_host or ":" not in resolved_host:
+        return False
+
+    base_parts = base_host.split("%", 1)
+    resolved_parts = resolved_host.split("%", 1)
+
+    if base_parts[0] != resolved_parts[0]:
+        return False
+
+    base_zone = base_parts[1] if len(base_parts) > 1 else None
+    resolved_zone = resolved_parts[1] if len(resolved_parts) > 1 else None
+
+    if base_zone is not None and resolved_zone is not None:
+        return base_zone == resolved_zone
+
+    return True
 
 
 class UpnpFactory:
@@ -211,7 +228,7 @@ class UpnpFactory:
         potential SSRF vector (e.g. cloud-metadata or loopback endpoints) and is
         refused in strict mode or skipped (with a warning) in non-strict mode.
         """
-        base_host = _strip_ipv6_zone_id(urllib.parse.urlparse(base_url).hostname)
+        base_host = urllib.parse.urlparse(base_url).hostname
         for tag in ("SCPDURL", "controlURL", "eventSubURL"):
             ref = service_description_el.findtext(f"device:{tag}", "", NS)
             if not ref:
@@ -220,10 +237,10 @@ class UpnpFactory:
             # urlparse raise; fail closed and treat it as a refused host.
             try:
                 resolved = urllib.parse.urljoin(base_url, ref)
-                resolved_host = _strip_ipv6_zone_id(urllib.parse.urlparse(resolved).hostname)
+                resolved_host = urllib.parse.urlparse(resolved).hostname
             except ValueError:
                 resolved_host = None
-            if resolved_host != base_host:
+            if resolved_host != base_host and not _ipv6_hosts_match(base_host, resolved_host):
                 reason = (
                     "is malformed"
                     if resolved_host is None

--- a/async_upnp_client/client_factory.py
+++ b/async_upnp_client/client_factory.py
@@ -73,6 +73,9 @@ def _ipv6_hosts_match(base_host: str | None, resolved_host: str | None) -> bool:
     if base_zone is not None and resolved_zone is not None:
         return base_zone == resolved_zone
 
+    if base_zone is None and resolved_zone is not None:
+        return False
+
     return True
 
 

--- a/changes/317.bugfix.rst
+++ b/changes/317.bugfix.rst
@@ -1,0 +1,1 @@
+Fix SSRF false positive on IPv6 link-local addresses where the device description URL carries a zone ID from SSDP discovery but absolute service URLs in the device XML omit it.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,7 @@
 """Unit tests for client_factory and client modules."""
 
+# pylint: disable=too-many-lines
+
 from datetime import datetime, timedelta, timezone
 from typing import MutableMapping
 
@@ -994,3 +996,16 @@ class TestServiceUrlSsrf:
 
         service = device.service("urn:schemas-upnp-org:service:Bar:1")
         assert service.control_url == "http://[fe80::218:ddff:fe0a:517d]:80/dms/control"
+
+    @pytest.mark.asyncio
+    async def test_ipv6_different_zone_ids_rejected_in_strict_mode(self) -> None:
+        """Service URLs with a different zone ID than the device URL are rejected."""
+        device_url = "http://[fe80::1%251]:80/device.xml"
+        xml = self._device_xml(
+            control_url="http://[fe80::1%252]:80/svc/control",
+        )
+        requester = UpnpTestRequester({("GET", device_url): HttpResponse(200, {}, xml)})
+        factory = UpnpFactory(requester)
+
+        with pytest.raises(UpnpError):
+            await factory.async_create_device(device_url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1022,3 +1022,16 @@ class TestServiceUrlSsrf:
 
         with pytest.raises(UpnpError):
             await factory.async_create_device(device_url)
+
+    @pytest.mark.asyncio
+    async def test_ipv6_different_addresses_with_zones_rejected(self) -> None:
+        """Different IPv6 addresses are rejected even when both carry zone IDs."""
+        device_url = "http://[fe80::1%251]:80/device.xml"
+        xml = self._device_xml(
+            control_url="http://[fe80::2%251]:80/svc/control",
+        )
+        requester = UpnpTestRequester({("GET", device_url): HttpResponse(200, {}, xml)})
+        factory = UpnpFactory(requester)
+
+        with pytest.raises(UpnpError):
+            await factory.async_create_device(device_url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1009,3 +1009,16 @@ class TestServiceUrlSsrf:
 
         with pytest.raises(UpnpError):
             await factory.async_create_device(device_url)
+
+    @pytest.mark.asyncio
+    async def test_ipv6_service_introduces_zone_rejected(self) -> None:
+        """A service URL that adds a zone ID absent from the device URL is rejected."""
+        device_url = "http://[fe80::1]:80/device.xml"
+        xml = self._device_xml(
+            control_url="http://[fe80::1%252]:80/svc/control",
+        )
+        requester = UpnpTestRequester({("GET", device_url): HttpResponse(200, {}, xml)})
+        factory = UpnpFactory(requester)
+
+        with pytest.raises(UpnpError):
+            await factory.async_create_device(device_url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -964,3 +964,33 @@ class TestServiceUrlSsrf:
 
         service = device.service("urn:schemas-upnp-org:service:Bar:1")
         assert service.control_url == "http://192.168.1.50:8080/svc/control"
+
+    @pytest.mark.asyncio
+    async def test_ipv6_link_local_zone_id_mismatch_allowed(self) -> None:
+        """Absolute service URLs without a zone ID match a device URL that has one.
+
+        SSDP discovery adds zone IDs to link-local IPv6 device URLs, but
+        devices typically omit them from service URLs in their XML. The SSRF
+        host comparison must strip zone IDs so these are not falsely rejected.
+        """
+        device_url = "http://[fe80::218:ddff:fe0a:517d%252]:80/dms/device.xml"
+        xml = self._device_xml(
+            scpd_url="http://[fe80::218:ddff:fe0a:517d]:80/svc.xml",
+            control_url="http://[fe80::218:ddff:fe0a:517d]:80/dms/control",
+            event_sub_url="http://[fe80::218:ddff:fe0a:517d]:80/dms/event",
+        )
+        requester = UpnpTestRequester(
+            {
+                ("GET", device_url): HttpResponse(200, {}, xml),
+                (
+                    "GET",
+                    "http://[fe80::218:ddff:fe0a:517d]:80/svc.xml",
+                ): HttpResponse(200, {}, self.SCPD_XML),
+            }
+        )
+        factory = UpnpFactory(requester, non_strict=True)
+
+        device = await factory.async_create_device(device_url)
+
+        service = device.service("urn:schemas-upnp-org:service:Bar:1")
+        assert service.control_url == "http://[fe80::218:ddff:fe0a:517d]:80/dms/control"


### PR DESCRIPTION
## Problem

The SSRF host validation added in commit 4b005375 compares service URL hostnames against the device description URL hostname using string equality. SSDP discovery adds zone IDs to link-local IPv6 device URLs (e.g. `fe80::218:ddff:fe0a:517d%2`), but devices typically omit zone IDs from absolute service URLs in their XML (e.g. `fe80::218:ddff:fe0a:517d`). The comparison fails and the service is skipped with a warning:

```
WARNING [async_upnp_client.client_factory] Service controlURL
  'http://[fe80::218:ddff:fe0a:517d]:80/dms/ConnectionManager' resolves
  to a different host than the device URL
  'http://[fe80::218:ddff:fe0a:517d%2]:80/dms/device.xml';
  refusing as potential SSRF; skipping service
```

## Fix

Adds `_ipv6_hosts_match()` as a fallback when the raw hostname strings differ. It only operates on IPv6 hostnames (must contain `:`), so non-IPv6 hostnames with percent-encoding are never affected. The comparison is directional to preserve the SSRF boundary:

- **Base has zone, service has none**: allowed (the normal SSDP discovery case)
- **Both have zones**: must match
- **Service introduces a zone absent from base**: rejected (could redirect to a different interface)

## Known limitation

When the match succeeds via the zone tolerance path, the resolved service URL retains its original (zone-less) form. On multi-interface hosts, a zone-less link-local address may be ambiguous. Propagating the base URL's zone ID into resolved service URLs would fully close this gap but requires changes to the URL handling pipeline that are better suited for a follow-up.

## Tests

Adds three test cases to `TestServiceUrlSsrf`:
- `test_ipv6_link_local_zone_id_mismatch_allowed`: base with zone, service without (the fix)
- `test_ipv6_different_zone_ids_rejected_in_strict_mode`: both with different zones (rejected)
- `test_ipv6_service_introduces_zone_rejected`: service adds zone absent from base (rejected)

All 254 tests pass.